### PR TITLE
refactor: use Bun.env instead of process.env

### DIFF
--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -1,6 +1,5 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { createLogger } from "../utils/logger.js";
-import process from "node:process";
 
 const logger = createLogger({ component: "supabase" });
 
@@ -24,8 +23,8 @@ export function getSupabaseClient(): SupabaseDatabase {
  * Initialize Supabase client and verify connection
  */
 export async function initSupabase(): Promise<void> {
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseKey = process.env.SUPABASE_SECRET_KEY;
+  const supabaseUrl = Bun.env.SUPABASE_URL;
+  const supabaseKey = Bun.env.SUPABASE_SECRET_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { tokenStore } from "./auth/token-store.js";
 import { createApp } from "./server/app.js";
 import { setOAuthConfig } from "./config.js";
 import { initRateLimiter } from "./server/rate-limiter.js";
-import process from "node:process";
 
 // Initialize Supabase first (required by all stores).
 // Expired-record cleanup is handled by pg_cron in the database
@@ -26,16 +25,16 @@ const requiredEnvVars = [
 ] as const;
 
 for (const envVar of requiredEnvVars) {
-  if (!process.env[envVar]) {
+  if (!Bun.env[envVar]) {
     throw new Error(`Missing required environment variable: ${envVar}`);
   }
 }
 
 // OAuth configuration from environment
 const oauthConfig = {
-  clientId: process.env.WITHINGS_CLIENT_ID!,
-  clientSecret: process.env.WITHINGS_CLIENT_SECRET!,
-  redirectUri: process.env.WITHINGS_REDIRECT_URI!,
+  clientId: Bun.env.WITHINGS_CLIENT_ID!,
+  clientSecret: Bun.env.WITHINGS_CLIENT_SECRET!,
+  redirectUri: Bun.env.WITHINGS_REDIRECT_URI!,
 };
 
 // Set global OAuth config
@@ -44,7 +43,7 @@ setOAuthConfig(oauthConfig);
 // Create and configure the app
 const app = createApp({ oauthConfig });
 
-const port = Number.parseInt(process.env.PORT ?? "8080", 10);
+const port = Number.parseInt(Bun.env.PORT ?? "8080", 10);
 
 // Bun picks up the default export and starts the HTTP server automatically
 export default {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,7 +6,6 @@ import { createOAuthRouter } from "../auth/oauth.js";
 import { authenticateBearer } from "./middleware.js";
 import { handleMcp } from "./mcp-endpoints.js";
 import type { AppEnv } from "../types/hono.js";
-import process from "node:process";
 
 export interface ServerConfig {
   oauthConfig: {
@@ -93,7 +92,7 @@ export function createApp(config: ServerConfig) {
       }
 
       // Allow configured origins (comma-separated list in env var)
-      const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()) || [];
+      const allowedOrigins = Bun.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()) || [];
       if (allowedOrigins.includes(origin)) {
         return origin;
       }

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import { Buffer } from "node:buffer";
-import process from "node:process";
 
 /**
  * Encryption utility for sensitive data using AES-256-GCM
@@ -24,7 +23,7 @@ function deriveKey(masterSecret: string, salt: Buffer): Buffer {
  * Get or generate encryption master secret from environment
  */
 function getMasterSecret(): string {
-  const secret = process.env.ENCRYPTION_SECRET;
+  const secret = Bun.env.ENCRYPTION_SECRET;
   if (!secret) {
     throw new Error(
       "ENCRYPTION_SECRET environment variable is required. Generate one with: openssl rand -hex 32"

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,7 +14,6 @@
  * - debug: Detailed diagnostic information (disabled in production)
  */
 
-import process from "node:process";
 const redactedFields = [
   // Authentication
   "token",
@@ -70,7 +69,7 @@ class Logger {
   private context: Record<string, unknown>;
 
   constructor(context: Record<string, unknown> = {}) {
-    const envLevel = (process.env.LOG_LEVEL || "info").toLowerCase() as LogLevel;
+    const envLevel = (Bun.env.LOG_LEVEL || "info").toLowerCase() as LogLevel;
     this.level = LOG_LEVELS[envLevel] || LOG_LEVELS.info;
     this.context = context;
   }


### PR DESCRIPTION
## Summary

Follow-up to #13. Swaps `process.env` for `Bun.env` across the codebase and drops the now-unused `import process from "node:process"` statements.

## Why

`Bun.env` is the idiomatic accessor on Bun — it's the same underlying environment object as `process.env`, just without needing to import the Node compatibility shim. Cleaner now that the runtime is Bun-only.

## Scope

Five files touched: [src/index.ts](https://github.com/akutishevsky/withings-mcp/blob/refactor/use-bun-env/src/index.ts), [src/db/supabase.ts](https://github.com/akutishevsky/withings-mcp/blob/refactor/use-bun-env/src/db/supabase.ts), [src/utils/encryption.ts](https://github.com/akutishevsky/withings-mcp/blob/refactor/use-bun-env/src/utils/encryption.ts), [src/utils/logger.ts](https://github.com/akutishevsky/withings-mcp/blob/refactor/use-bun-env/src/utils/logger.ts), [src/server/app.ts](https://github.com/akutishevsky/withings-mcp/blob/refactor/use-bun-env/src/server/app.ts).

No behavior change — same values read from the same environment.

## Test plan

- [ ] `bun install`
- [ ] `bun run typecheck` passes
- [ ] Server boots locally with real env vars
- [ ] Deployed instance on DigitalOcean still reads SUPABASE_URL, WITHINGS_*, ENCRYPTION_SECRET, PORT, LOG_LEVEL, ALLOWED_ORIGINS correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)