### PR TITLE
fix: rename SUPABASE_SECRET_KEY to SUPABASE_SERVICE_ROLE_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ ENCRYPTION_SECRET=your_encryption_secret_here_min_32_chars
 # Supabase Configuration (REQUIRED)
 # Get these from Supabase Dashboard → Settings → API
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SECRET_KEY=your_secret_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_secret_key_here
 
 # CORS Configuration (optional)
 # Comma-separated list of allowed origins for browser requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ Required:
 - `WITHINGS_REDIRECT_URI`: Callback URL (must match Withings app settings)
 - `ENCRYPTION_SECRET`: Secret key for encrypting tokens at rest (min 32 chars, generate with `npm run generate-secret` or `openssl rand -hex 32`)
 - `SUPABASE_URL`: Supabase project URL (from Dashboard → Settings → API)
-- `SUPABASE_SECRET_KEY`: Supabase service role key (from Dashboard → Settings → API)
+- `SUPABASE_SERVICE_ROLE_KEY`: Supabase service role key (from Dashboard → Settings → API)
 
 Optional:
 - `PORT`: Server port (default: 3000)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ bun run generate-secret
 4. Apply the database migrations: `supabase db push`
 5. Get your credentials from Dashboard → Settings → API:
    - **Project URL** → `SUPABASE_URL`
-   - **Service role key** → `SUPABASE_SECRET_KEY`
+   - **Service role key** → `SUPABASE_SERVICE_ROLE_KEY`
 
 ### Step 3: Local Development
 
@@ -220,7 +220,7 @@ cp .env.example .env
 # WITHINGS_REDIRECT_URI=https://your-tunnel-url.com/callback
 # ENCRYPTION_SECRET=paste_generated_secret_here
 # SUPABASE_URL=https://your-project.supabase.co
-# SUPABASE_SECRET_KEY=your_service_role_key
+# SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 # PORT=3000
 
 # Run locally (Bun executes TypeScript directly — no build step)
@@ -247,7 +247,7 @@ Set the following environment variables on your hosting platform:
 | `WITHINGS_REDIRECT_URI` | Yes | `https://your-domain.com/callback` |
 | `ENCRYPTION_SECRET` | Yes | Generated from step 2 |
 | `SUPABASE_URL` | Yes | `https://your-project.supabase.co` |
-| `SUPABASE_SECRET_KEY` | Yes | Your Supabase service role key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Your Supabase service role key |
 | `PORT` | No | `3000` (or your platform's default) |
 | `LOG_LEVEL` | No | `info` |
 | `ALLOWED_ORIGINS` | No | `https://example.com,https://app.example.com` |
@@ -288,7 +288,7 @@ Configure your MCP client with the following connection details:
 | `WITHINGS_REDIRECT_URI` | Yes | OAuth callback URL (must match Withings app settings) |
 | `ENCRYPTION_SECRET` | Yes | 32+ character secret for token encryption (generate with `bun run generate-secret`) |
 | `SUPABASE_URL` | Yes | Your Supabase project URL (from Dashboard → Settings → API) |
-| `SUPABASE_SECRET_KEY` | Yes | Your Supabase service role key (from Dashboard → Settings → API) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Your Supabase service role key (from Dashboard → Settings → API) |
 | `PORT` | No | Server port (default: 3000) |
 | `LOG_LEVEL` | No | Logging level: trace, debug, info, warn, error (default: info) |
 | `ALLOWED_ORIGINS` | No | Comma-separated list of allowed CORS origins for browser clients |

--- a/src/db/supabase.ts
+++ b/src/db/supabase.ts
@@ -24,11 +24,11 @@ export function getSupabaseClient(): SupabaseDatabase {
  */
 export async function initSupabase(): Promise<void> {
   const supabaseUrl = Bun.env.SUPABASE_URL;
-  const supabaseKey = Bun.env.SUPABASE_SECRET_KEY;
+  const supabaseKey = Bun.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
     throw new Error(
-      "Missing Supabase environment variables. Set SUPABASE_URL and SUPABASE_SECRET_KEY."
+      "Missing Supabase environment variables. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY."
     );
   }
 


### PR DESCRIPTION
## Summary

Rename the Supabase key env var from \`SUPABASE_SECRET_KEY\` to \`SUPABASE_SERVICE_ROLE_KEY\` to match Supabase's own terminology.

## Why

Supabase exposes this key in its dashboard as the **service role key**, and our own README already described it that way — but the env var name didn't match, which caused a silent config mismatch on DigitalOcean App Platform (the var was set under the Supabase-native name, but the code read the old name, so startup failed with \`Missing Supabase environment variables\`).

## Scope

- [src/db/supabase.ts](https://github.com/akutishevsky/withings-mcp/blob/fix/rename-supabase-key-env-var/src/db/supabase.ts) — the only runtime read site
- [.env.example](https://github.com/akutishevsky/withings-mcp/blob/fix/rename-supabase-key-env-var/.env.example)
- [README.md](https://github.com/akutishevsky/withings-mcp/blob/fix/rename-supabase-key-env-var/README.md) — 4 references in the self-hosting docs
- [CLAUDE.md](https://github.com/akutishevsky/withings-mcp/blob/fix/rename-supabase-key-env-var/CLAUDE.md) — 1 reference in the env var list

## Breaking change

Self-hosters must rename the env var in their deployment before this change lands. The hosted instance (DigitalOcean) will need the var renamed at the same time.

## Test plan

- [ ] \`bun run typecheck\` passes
- [ ] Server boots locally with \`SUPABASE_SERVICE_ROLE_KEY\` set
- [ ] Fresh deploy on DigitalOcean succeeds — no \`Missing Supabase environment variables\` crash, readiness probe passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)