### PR TITLE
fix: advertise https in OAuth discovery behind TLS proxy

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -163,7 +163,14 @@ export function createApp(config: ServerConfig) {
 
   // OAuth metadata discovery endpoint
   app.get("/.well-known/oauth-authorization-server", (c) => {
-    const baseUrl = new URL(c.req.url).origin;
+    // Respect x-forwarded-proto so the discovery doc advertises https when the
+    // server sits behind a TLS-terminating reverse proxy (Cloudflare, DO App Platform).
+    const url = new URL(c.req.url);
+    const forwardedProto = c.req.header("x-forwarded-proto");
+    if (forwardedProto) {
+      url.protocol = `${forwardedProto.split(",")[0].trim()}:`;
+    }
+    const baseUrl = url.origin;
     return c.json({
       issuer: baseUrl,
       authorization_endpoint: `${baseUrl}/authorize`,


### PR DESCRIPTION
## Summary

The \`/.well-known/oauth-authorization-server\` endpoint was emitting \`http://\` URLs for \`issuer\`, \`authorization_endpoint\`, \`token_endpoint\`, etc., because it built the base URL from \`c.req.url.origin\` — which reflects the internal (pre-proxy) scheme. Cloudflare / DO App Platform terminate TLS upstream, so Bun sees \`http://\`.

Claude Desktop refuses to run OAuth over \`http\` and bounces the user back with \"Couldn't connect.\"

Fix: respect \`x-forwarded-proto\` when constructing the discovery doc's base URL.

## Test plan

- [ ] \`curl https://withings-mcp.com/.well-known/oauth-authorization-server\` returns \`https://\` for every URL
- [ ] Claude Desktop \"Add Custom Connector → Connect\" completes the OAuth handshake end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)