### PR TITLE
fix: advertise auth server via WWW-Authenticate + RFC 9728 metadata

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -18,6 +18,23 @@ export interface ServerConfig {
 const MCP_ENDPOINT = "/mcp";
 
 /**
+ * Resolve the externally-visible base URL for this request.
+ * Honors x-forwarded-proto so URLs advertised to clients use https when the
+ * server sits behind a TLS-terminating reverse proxy (Cloudflare, DO App Platform).
+ */
+// deno-lint-ignore no-explicit-any
+function getPublicBaseUrl(c: any): string {
+  const url = new URL(c.req.url);
+  const forwardedProto = c.req.header("x-forwarded-proto");
+  if (forwardedProto) {
+    url.protocol = `${forwardedProto.split(",")[0].trim()}:`;
+  }
+  return url.origin;
+}
+
+export { getPublicBaseUrl };
+
+/**
  * Create and configure the Hono application
  */
 export function createApp(config: ServerConfig) {
@@ -161,16 +178,9 @@ export function createApp(config: ServerConfig) {
   // MCP endpoint — SDK transport handles GET, POST, DELETE internally
   app.all(MCP_ENDPOINT, authenticateBearer, handleMcp);
 
-  // OAuth metadata discovery endpoint
+  // OAuth Authorization Server Metadata (RFC 8414)
   app.get("/.well-known/oauth-authorization-server", (c) => {
-    // Respect x-forwarded-proto so the discovery doc advertises https when the
-    // server sits behind a TLS-terminating reverse proxy (Cloudflare, DO App Platform).
-    const url = new URL(c.req.url);
-    const forwardedProto = c.req.header("x-forwarded-proto");
-    if (forwardedProto) {
-      url.protocol = `${forwardedProto.split(",")[0].trim()}:`;
-    }
-    const baseUrl = url.origin;
+    const baseUrl = getPublicBaseUrl(c);
     return c.json({
       issuer: baseUrl,
       authorization_endpoint: `${baseUrl}/authorize`,
@@ -182,6 +192,19 @@ export function createApp(config: ServerConfig) {
       token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
       // MCP-specific metadata
       mcp_endpoint: `${baseUrl}${MCP_ENDPOINT}`,
+    });
+  });
+
+  // OAuth Protected Resource Metadata (RFC 9728) — tells MCP clients which
+  // authorization server protects this resource. Required by the MCP 2025-06-18
+  // auth spec so clients know to run OAuth discovery after a 401 from /mcp.
+  app.get("/.well-known/oauth-protected-resource", (c) => {
+    const baseUrl = getPublicBaseUrl(c);
+    return c.json({
+      resource: baseUrl,
+      authorization_servers: [baseUrl],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [],
     });
   });
 

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -1,8 +1,24 @@
 import { tokenStore } from "../auth/token-store.js";
 import { createLogger } from "../utils/logger.js";
+import { getPublicBaseUrl } from "./app.js";
 import type { AppContext, AppNext } from "../types/hono.js";
 
 const logger = createLogger({ component: "middleware" });
+
+/**
+ * Build the WWW-Authenticate header pointing MCP clients at the Protected
+ * Resource Metadata document (RFC 9728). Without this, clients receive a bare
+ * 401 and have no way to discover the authorization server.
+ */
+function buildWwwAuthenticate(c: AppContext, error: "missing_token" | "invalid_token"): string {
+  const resourceMetadata = `${getPublicBaseUrl(c)}/.well-known/oauth-protected-resource`;
+  const errorCode = error === "invalid_token" ? "invalid_token" : undefined;
+  const parts = [`Bearer realm="mcp"`, `resource_metadata="${resourceMetadata}"`];
+  if (errorCode) {
+    parts.push(`error="${errorCode}"`);
+  }
+  return parts.join(", ");
+}
 
 /**
  * Bearer token authentication middleware
@@ -15,6 +31,7 @@ export const authenticateBearer = async (c: AppContext, next: AppNext) => {
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     logger.warn(`Authentication failed on ${method} ${path}: missing or invalid authorization header`);
+    c.header("WWW-Authenticate", buildWwwAuthenticate(c, "missing_token"));
     return c.json({ error: "unauthorized", error_description: "Bearer token required" }, 401);
   }
 
@@ -22,6 +39,7 @@ export const authenticateBearer = async (c: AppContext, next: AppNext) => {
   const isValid = await tokenStore.isValid(token);
   if (!isValid) {
     logger.warn(`Authentication failed on ${method} ${path}: invalid or expired token`);
+    c.header("WWW-Authenticate", buildWwwAuthenticate(c, "invalid_token"));
     return c.json({ error: "invalid_token", error_description: "Token is invalid or expired" }, 401);
   }
 


### PR DESCRIPTION
## Summary

Claude Desktop was silently giving up after its first unauthenticated POST to \`/mcp\` — logs showed a single 401 and no follow-up OAuth requests. Root cause: the 401 didn't tell clients how to discover the authorization server.

MCP's [2025-06-18 auth spec](https://spec.modelcontextprotocol.io/specification/2025-06-18/basic/authorization/) requires protected resources to:

1. Emit \`WWW-Authenticate: Bearer realm=\"mcp\", resource_metadata=\"<url>\"\` on 401 responses
2. Host a [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) Protected Resource Metadata document at that URL, which points at the authorization server(s)

Clients read the header on 401, fetch the metadata doc, and then hit the authorization server's own \`.well-known/oauth-authorization-server\` to discover OAuth endpoints. Without either piece, they have nothing to follow.

## Changes

- [src/server/middleware.ts](https://github.com/akutishevsky/withings-mcp/blob/fix/oauth-protected-resource-metadata/src/server/middleware.ts): set \`WWW-Authenticate\` on both 401 paths (missing token / invalid token)
- [src/server/app.ts](https://github.com/akutishevsky/withings-mcp/blob/fix/oauth-protected-resource-metadata/src/server/app.ts): add \`/.well-known/oauth-protected-resource\` handler; extract \`getPublicBaseUrl()\` helper so both discovery docs honor \`x-forwarded-proto\`

## Test plan

- [ ] \`curl -i https://withings-mcp.com/mcp\` 401 response includes \`WWW-Authenticate: Bearer realm=\"mcp\", resource_metadata=\"https://withings-mcp.com/.well-known/oauth-protected-resource\"\`
- [ ] \`curl https://withings-mcp.com/.well-known/oauth-protected-resource\` returns a JSON doc with \`authorization_servers: [\"https://withings-mcp.com\"]\`
- [ ] Claude Desktop \"Connect\" completes the full OAuth handshake end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)