### PR TITLE
feat: access log middleware for request-level visibility

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,7 +5,10 @@ import { readFile } from "node:fs/promises";
 import { createOAuthRouter } from "../auth/oauth.js";
 import { authenticateBearer } from "./middleware.js";
 import { handleMcp } from "./mcp-endpoints.js";
+import { createLogger } from "../utils/logger.js";
 import type { AppEnv } from "../types/hono.js";
+
+const accessLogger = createLogger({ component: "access" });
 
 export interface ServerConfig {
   oauthConfig: {
@@ -39,6 +42,17 @@ export { getPublicBaseUrl };
  */
 export function createApp(config: ServerConfig) {
   const app = new Hono<AppEnv>();
+
+  // Access log — records every inbound request so we can see what a client is
+  // (or isn't) hitting. Runs first so even 4xx/5xx / short-circuit responses
+  // from later middleware are logged.
+  app.use("*", async (c, next) => {
+    const start = Date.now();
+    const ua = c.req.header("user-agent") || "-";
+    await next();
+    const ms = Date.now() - start;
+    accessLogger.info(`${c.req.method} ${c.req.path} -> ${c.res.status} ${ms}ms ua="${ua}"`);
+  });
 
   // HTTPS redirect in production (behind reverse proxy)
   app.use("*", async (c, next) => {


### PR DESCRIPTION
## Summary

Add a Hono middleware that emits one log line per inbound request:

\`\`\`
INFO [access] GET /.well-known/oauth-protected-resource -> 200 3ms ua=\"Claude/...\"
\`\`\`

Runs first in the middleware chain, so even short-circuit responses from auth, CORS, body-limit, etc. are still logged.

## Why

We're debugging an MCP client (Claude Desktop) that appears to send no follow-up requests after an initial 401. Without request-level logging we can't distinguish:
- the client isn't making the requests at all
- the requests are being blocked at the edge (Cloudflare) before reaching DO
- the requests reach DO but hit handlers we don't currently log

One line per request resolves all three cases at a glance.

## Test plan

- [ ] Hitting \`GET /\` produces an \`INFO [access] GET / -> 200 ...\` log line
- [ ] Hitting \`POST /mcp\` with no auth still produces an access log line (runs before the 401 short-circuit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)