### PR TITLE
chore: log session-lookup details for MCP endpoint

### DIFF
--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -25,8 +25,19 @@ export const handleMcp = async (c: AppContext) => {
   // Look up existing session
   const session = sessionId ? sessions.get(sessionId) : undefined;
 
+  logger.debug("MCP request", {
+    method: c.req.method,
+    hasSessionIdHeader: Boolean(sessionId),
+    sessionFound: Boolean(session),
+    activeSessions: sessions.size,
+  });
+
   // Session ID provided but not found
   if (sessionId && !session) {
+    logger.warn("MCP session lookup miss", {
+      method: c.req.method,
+      activeSessions: sessions.size,
+    });
     return c.json({
       error: "invalid_session",
       error_description: "Session not found or expired"
@@ -49,6 +60,10 @@ export const handleMcp = async (c: AppContext) => {
 
   // No session — only POST can initialize
   if (c.req.method !== "POST") {
+    logger.warn("MCP non-POST without session", {
+      method: c.req.method,
+      hasSessionIdHeader: Boolean(sessionId),
+    });
     return c.json({
       error: "invalid_request",
       error_description: "No session. Send an initialization POST to create one."


### PR DESCRIPTION
## Summary

OAuth is now working but \`GET /mcp\` immediately after the \`POST /mcp\` that established a session is 400ing. Not enough detail in logs to know whether the client is forgetting the \`Mcp-Session-Id\` header, sending a stale one, or racing a session eviction.

This PR adds:

- A \`DEBUG [mcp-endpoints] MCP request\` line per request, showing \`method\`, \`hasSessionIdHeader\`, \`sessionFound\`, and the current \`activeSessions\` count.
- A \`WARN\` on the 404 session-miss path and on the 400 non-POST-without-session path, with the same context, so these cases are visible even when log level isn't debug.

Strictly diagnostic — no behavior change.

## Test plan

- [ ] Redeploy with \`LOG_LEVEL=debug\`, retry Claude Desktop "Connect", and check Runtime Logs for the new lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)