### PR TITLE
fix: protected resource metadata identifies /mcp endpoint

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,7 +6,7 @@ import { createOAuthRouter } from "../auth/oauth.js";
 import { authenticateBearer } from "./middleware.js";
 import { handleMcp } from "./mcp-endpoints.js";
 import { createLogger } from "../utils/logger.js";
-import type { AppEnv } from "../types/hono.js";
+import type { AppContext, AppEnv } from "../types/hono.js";
 
 const accessLogger = createLogger({ component: "access" });
 
@@ -212,15 +212,22 @@ export function createApp(config: ServerConfig) {
   // OAuth Protected Resource Metadata (RFC 9728) — tells MCP clients which
   // authorization server protects this resource. Required by the MCP 2025-06-18
   // auth spec so clients know to run OAuth discovery after a 401 from /mcp.
-  app.get("/.well-known/oauth-protected-resource", (c) => {
+  //
+  // RFC 9728 allows a resource-path-suffixed metadata URL, so we also serve
+  // the same document at /.well-known/oauth-protected-resource/mcp for clients
+  // that resolve the metadata URL from the resource identifier.
+  const protectedResourceMetadata = (c: AppContext) => {
     const baseUrl = getPublicBaseUrl(c);
     return c.json({
-      resource: baseUrl,
+      // `resource` MUST be the full resource identifier — i.e. the MCP endpoint.
+      resource: `${baseUrl}${MCP_ENDPOINT}`,
       authorization_servers: [baseUrl],
       bearer_methods_supported: ["header"],
       scopes_supported: [],
     });
-  });
+  };
+  app.get("/.well-known/oauth-protected-resource", protectedResourceMetadata);
+  app.get("/.well-known/oauth-protected-resource/mcp", protectedResourceMetadata);
 
   // Favicon endpoint
   app.get("/favicon.ico", async (c) => {


### PR DESCRIPTION
## Summary

Two tweaks to the RFC 9728 protected resource metadata doc that are most-likely blocking Claude Desktop's OAuth discovery:

1. **\`resource\` must be the full resource identifier.** We were returning \`https://withings-mcp.com\` (the origin); per RFC 9728 it must be \`https://withings-mcp.com/mcp\` (the MCP endpoint). Clients compare this against the resource they're trying to reach and silently reject the doc on mismatch.

2. **Also serve at \`/.well-known/oauth-protected-resource/mcp\`.** RFC 9728 §3 allows resolving the metadata URL by prefixing \`.well-known\` onto the resource's path, so some clients look here specifically. We now respond at both paths with the same doc.

## Context

Claude Desktop currently aborts after the initial 401 probe of \`/mcp\` — no \`/register\`, \`/authorize\`, or \`/.well-known/*\` follow-ups land in the access log. The most plausible remaining cause is Claude reading the metadata doc, seeing the mismatched \`resource\` field, and giving up silently.

## Test plan

- [ ] \`curl https://withings-mcp.com/.well-known/oauth-protected-resource\` returns \`resource: "https://withings-mcp.com/mcp"\`
- [ ] Same doc is served at \`/.well-known/oauth-protected-resource/mcp\`
- [ ] Claude Desktop "Connect" completes end-to-end OAuth and establishes an MCP session

🤖 Generated with [Claude Code](https://claude.com/claude-code)