### PR TITLE
fix: 405 (not 400) for GET/DELETE /mcp without session

### DIFF
--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -58,16 +58,22 @@ export const handleMcp = async (c: AppContext) => {
     return session.transport.handleRequest(c.req.raw);
   }
 
-  // No session — only POST can initialize
+  // No session — only POST can initialize.
+  //
+  // Per MCP Streamable HTTP spec, GET/DELETE without a session must return
+  // 405 Method Not Allowed (not 400). Some clients treat 4xx_non_405 as a
+  // permanent server error and abandon the connection, whereas 405 signals
+  // "try a different method" and nudges them to re-initialize via POST.
   if (c.req.method !== "POST") {
     logger.warn("MCP non-POST without session", {
       method: c.req.method,
       hasSessionIdHeader: Boolean(sessionId),
     });
+    c.header("Allow", "POST");
     return c.json({
-      error: "invalid_request",
-      error_description: "No session. Send an initialization POST to create one."
-    }, 400);
+      error: "method_not_allowed",
+      error_description: "No active session. Send an initialization POST first."
+    }, 405);
   }
 
   // New session — create transport + server


### PR DESCRIPTION
## Summary

Change sessionless GET/DELETE on /mcp from 400 to 405 Method Not Allowed and add the \`Allow: POST\` header. Per MCP Streamable HTTP spec, 405 is the correct response and signals to clients "retry with the allowed method" rather than "server is broken."

## Context

Claude Desktop's reconnect flow looks like:

\`\`\`
GET /mcp (auth'd, no session id) -> 400  ← we were here
... Claude gives up ...
\`\`\`

Claude is apparently treating the 400 as a terminal server error and abandoning instead of falling back to a POST initialize. 405 with an \`Allow: POST\` header should flip it into re-initialization mode.

## Test plan

- [ ] \`curl -i -H \"Authorization: Bearer <valid>\" https://withings-mcp.com/mcp\` returns 405 with \`Allow: POST\`
- [ ] Claude Desktop "Connect" completes end-to-end and tools become listable

🤖 Generated with [Claude Code](https://claude.com/claude-code)