### PR TITLE
fix: disable Bun idleTimeout so MCP SSE streams aren't killed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,14 @@ const app = createApp({ oauthConfig });
 
 const port = Number.parseInt(Bun.env.PORT ?? "8080", 10);
 
-// Bun picks up the default export and starts the HTTP server automatically
+// Bun picks up the default export and starts the HTTP server automatically.
+//
+// idleTimeout defaults to 10 seconds, which kills long-lived SSE streams
+// used by MCP's Streamable HTTP transport (GET /mcp stays open to push
+// server->client events). Setting it to 0 disables the per-request idle
+// timeout so the transport decides when to close.
 export default {
   fetch: app.fetch,
   port,
+  idleTimeout: 0,
 };


### PR DESCRIPTION
## Summary

Set \`idleTimeout: 0\` on the Bun HTTP server so long-lived SSE streams aren't severed after 10 seconds.

## Context

Runtime logs showed this after a successful \`GET /mcp\` (the SSE stream from MCP's Streamable HTTP transport):

\`\`\`
INFO  [access] GET /mcp -> 200 187ms ua=\"Claude-User\"
[Bun.serve]: request timed out after 10 seconds. Pass \`idleTimeout\` to configure.
\`\`\`

\`Bun.serve\` defaults to a 10-second per-request idle timeout. MCP's transport holds the GET stream open to push server->client events, and goes quiet between events. Bun was killing the socket, which is the reason Claude Desktop shows \"Couldn't connect\" after a successful Withings login — the session is established, but the stream dies immediately after.

\`idleTimeout: 0\` disables the per-request timeout. The SDK transport manages stream lifecycle itself via heartbeats and explicit close on DELETE, so we don't need Bun to police it.

## Test plan

- [ ] Connect from Claude Desktop; after Withings login, tools appear in Claude and at least one tool call succeeds end-to-end.
- [ ] No more \"request timed out after 10 seconds\" lines in runtime logs during an active session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)