### PR TITLE
fix: disable edge buffering and keep /mcp SSE streams alive

### DIFF
--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -13,6 +13,91 @@ const sessions = new Map<string, {
 }>();
 
 /**
+ * SSE keep-alive ping interval. Empty SSE comment lines every 15s prevent
+ * Cloudflare (which fronts DO App Platform) and strict clients from closing
+ * idle streams. 15s is well under Cloudflare's 100s HTTP/2 stream idle limit
+ * and under most client read timeouts.
+ */
+const SSE_KEEPALIVE_MS = 15_000;
+
+/**
+ * Wrap the SDK transport's Response for SSE streams:
+ *  - Tell Cloudflare / any nginx-style proxy NOT to buffer the stream
+ *    (X-Accel-Buffering: no). Without this, proxies may hold the stream
+ *    until enough bytes accumulate, causing clients to time out waiting.
+ *  - Inject SSE keep-alive comments every 15s so the connection stays
+ *    observably alive end-to-end.
+ *
+ * Non-SSE responses pass through unchanged.
+ */
+function prepareSseResponse(res: Response): Response {
+  const contentType = res.headers.get("content-type") || "";
+  if (!contentType.includes("text/event-stream") || !res.body) {
+    return res;
+  }
+
+  // Clone headers and disable edge buffering.
+  const headers = new Headers(res.headers);
+  headers.set("X-Accel-Buffering", "no");
+
+  // Inject keep-alive comments alongside the transport's own writes.
+  const encoder = new TextEncoder();
+  const keepAlive = encoder.encode(":keep-alive\n\n");
+  const upstream = res.body;
+
+  const merged = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const reader = upstream.getReader();
+      let closed = false;
+
+      const interval = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(keepAlive);
+        } catch {
+          clearInterval(interval);
+        }
+      }, SSE_KEEPALIVE_MS);
+
+      const pump = async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+        } catch (err) {
+          logger.warn("SSE upstream read failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        } finally {
+          closed = true;
+          clearInterval(interval);
+          try {
+            controller.close();
+          } catch {
+            // controller already closed
+          }
+        }
+      };
+
+      pump();
+    },
+    cancel(reason) {
+      logger.debug("SSE stream cancelled by client", {
+        reason: reason instanceof Error ? reason.message : String(reason ?? "unknown"),
+      });
+    },
+  });
+
+  return new Response(merged, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}
+
+/**
  * Unified handler for /mcp endpoint (GET, POST, DELETE).
  * Uses the SDK's WebStandardStreamableHTTPServerTransport which handles
  * all protocol details internally (SSE streaming, JSON-RPC validation,
@@ -55,7 +140,7 @@ export const handleMcp = async (c: AppContext) => {
 
   // Existing session — forward to its transport
   if (session) {
-    return session.transport.handleRequest(c.req.raw);
+    return prepareSseResponse(await session.transport.handleRequest(c.req.raw));
   }
 
   // No session — only POST can initialize.
@@ -96,5 +181,5 @@ export const handleMcp = async (c: AppContext) => {
   registerAllTools(server, mcpToken);
   await server.connect(transport);
 
-  return transport.handleRequest(c.req.raw);
+  return prepareSseResponse(await transport.handleRequest(c.req.raw));
 };


### PR DESCRIPTION
## Summary

Wrap the SDK transport's Response for SSE streams so they survive behind Cloudflare (DO App Platform's edge):

1. **\`X-Accel-Buffering: no\`** on \`text/event-stream\` responses. Without it, nginx/Cloudflare buffer SSE until enough bytes accumulate — clients time out before ever seeing the first event.
2. **15-second keep-alive comments** (\`:keep-alive\\n\\n\`) injected alongside the transport's own writes. Cloudflare closes idle HTTP/2 streams after ~100s; Claude Desktop's MCP client gives up sooner. Keep-alive keeps the connection observably active end-to-end.

Non-SSE responses (regular JSON POST/DELETE) pass through unchanged.

## Why

The most recent logs for a Claude Desktop Connect attempt showed:

- OAuth completes cleanly (\`/register → /authorize → /callback → /token\` all 200/302)
- POST \`/mcp\` 200 (session established)
- POST \`/mcp\` 202 (initialized notification)
- GET \`/mcp\` 200 (SSE stream opened)
- ← Claude Desktop reports \"Couldn't connect\" here
- Later, \`GET /mcp\` arrives without a session ID header (Claude retrying from scratch)

VSCode works against the exact same server end-to-end. The difference: Claude's SSE read timeout is apparently stricter, and if Cloudflare doesn't flush the stream (or no bytes arrive for ~15s+), Claude disconnects.

## Test plan

- [ ] \`curl -iN -H \"Authorization: Bearer <valid>\" -H \"Accept: text/event-stream\" https://withings-mcp.com/mcp\` returns \`X-Accel-Buffering: no\` and emits \`:keep-alive\` lines every ~15s
- [ ] Claude Desktop Connect completes and tools become usable end-to-end
- [ ] Runtime logs show a single \`MCP session established\` followed by sustained activity (POST tool calls) rather than repeated new-session-then-abandon cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)