### PR TITLE
fix: flush initial keep-alive byte on SSE streams

### DIFF
--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -47,6 +47,17 @@ function prepareSseResponse(res: Response): Response {
 
   const merged = new ReadableStream<Uint8Array>({
     start(controller) {
+      // Flush an initial keep-alive immediately so the client (and any
+      // buffering proxy in front of us) sees bytes right away and treats
+      // the stream as live. Without this first byte, Cloudflare may buffer
+      // the response and Claude Desktop times out before the SDK writes
+      // anything of its own.
+      try {
+        controller.enqueue(keepAlive);
+      } catch {
+        // controller unexpectedly closed already; nothing to do
+      }
+
       const reader = upstream.getReader();
       let closed = false;
 


### PR DESCRIPTION
## Summary

Enqueue a \`:keep-alive\\n\\n\` comment the moment the wrapped SSE \`ReadableStream\` starts, so the client (and any buffering proxy) receives the first bytes immediately — before the SDK transport has anything of its own to push.

## Why

Current runtime logs show Claude Desktop establishing a session, opening \`GET /mcp\` (200), then silently re-initializing a fresh session every ~10 seconds. \`activeSessions\` climbs to 5+ as Claude abandons each one. Classic signature of a client timing out on an SSE stream that has been opened but hasn't produced any bytes yet — Cloudflare's response buffering holds the stream until enough data accumulates, and Claude Desktop gives up before that happens.

The previous keep-alive fix sent a ping every 15 seconds, but the *first* ping only fires 15 seconds after the stream starts. If the client's read timeout is shorter (or Cloudflare buffers longer), 15s is too late. Flushing at t=0 guarantees a byte is already in flight by the time the Response headers reach the client.

VSCode tolerates the silent-stream case; Claude Desktop apparently doesn't.

## Test plan

- [ ] \`curl -iN -H 'Authorization: Bearer <valid>' -H 'Accept: text/event-stream' https://withings-mcp.com/mcp\` prints \`:keep-alive\` within the first second, not after 15 seconds.
- [ ] Claude Desktop Connect completes end-to-end and tools become usable; runtime logs show a single stable session rather than repeated re-initializations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)