### PR TITLE
fix: implement OAuth refresh_token grant and include in /token response

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -400,7 +400,7 @@ export function createOAuthRouter(config: OAuthConfig) {
     return c.redirect(redirectUrl.toString());
   });
 
-  // Token endpoint - MCP client exchanges code for token
+  // Token endpoint - MCP client exchanges code for token, or refreshes it
   oauth.post(
     "/token",
     rateLimit({ maxRequests: 100, windowMs: 3600000 }), // 100 requests per hour
@@ -410,6 +410,32 @@ export function createOAuthRouter(config: OAuthConfig) {
     const code = body.code as string;
     const codeVerifier = body.code_verifier as string;
     const redirectUri = body.redirect_uri as string;
+
+    // refresh_token grant (RFC 6749 §6). Rotate the MCP token value and
+    // return the new pair. The Withings credentials stored alongside the
+    // token are preserved — this only refreshes the opaque MCP-layer token.
+    if (grantType === "refresh_token") {
+      const refreshToken = body.refresh_token as string;
+      if (!refreshToken) {
+        return c.json({ error: "invalid_request" }, 400);
+      }
+      const existing = await tokenStore.getTokens(refreshToken);
+      if (!existing) {
+        return c.json({ error: "invalid_grant" }, 400);
+      }
+      const newToken = crypto.randomUUID();
+      await tokenStore.rotateToken(refreshToken, newToken);
+
+      const MCP_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+      c.header("Cache-Control", "no-store");
+      c.header("Pragma", "no-cache");
+      return c.json({
+        access_token: newToken,
+        token_type: "Bearer",
+        expires_in: MCP_TOKEN_TTL_SECONDS,
+        refresh_token: newToken,
+      });
+    }
 
     if (grantType !== "authorization_code") {
       logger.warn("Token exchange failed: unsupported grant type");
@@ -494,10 +520,17 @@ export function createOAuthRouter(config: OAuthConfig) {
       // Server handles refreshing Withings tokens transparently
       const MCP_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
+      // RFC 6749 §5.1: token endpoint responses MUST NOT be cached.
+      // refresh_token intentionally shares the mcpToken value — this project
+      // uses a single opaque MCP token that can be rotated via the
+      // refresh_token grant (see rotateToken in token-store.ts).
+      c.header("Cache-Control", "no-store");
+      c.header("Pragma", "no-cache");
       return c.json({
         access_token: mcpToken,
         token_type: "Bearer",
         expires_in: MCP_TOKEN_TTL_SECONDS,
+        refresh_token: mcpToken,
       });
     } catch (error) {
       logger.error("Token exchange error", { error: String(error) });

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -124,6 +124,27 @@ class TokenStore {
       throw new Error(`Failed to delete token: ${error.message}`);
     }
   }
+
+  // Rotate the MCP token (for OAuth refresh_token grant). Keeps all stored
+  // Withings credentials and user mapping intact, just swaps the public-facing
+  // token value and extends the TTL.
+  async rotateToken(oldToken: string, newToken: string): Promise<void> {
+    const supabase = getSupabaseClient();
+    const expiresAt = new Date(Date.now() + TTL_MS).toISOString();
+
+    const { error } = await supabase
+      .from("mcp_tokens")
+      .update({
+        mcp_token: newToken,
+        expires_at: expiresAt,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("mcp_token", oldToken);
+
+    if (error) {
+      throw new Error(`Failed to rotate token: ${error.message}`);
+    }
+  }
 }
 
 export const tokenStore = new TokenStore();


### PR DESCRIPTION
## Summary

Implement the \`refresh_token\` grant in \`/token\` and include a \`refresh_token\` field in successful token responses, bringing this server in line with the working [nutrition-mcp](https://github.com/akutishevsky/nutrition-mcp) reference.

## Why

We advertise support for \`refresh_token\` in both the RFC 8414 metadata doc (\`grant_types_supported\`) and the RFC 7591 registration response (\`grant_types\`), but:

- \`/token\` successful responses didn't include a \`refresh_token\` field
- \`/token\` rejected \`grant_type=refresh_token\` with \`unsupported_grant_type\`

That mismatch is the most plausible remaining cause of Claude Desktop's \"Authorization with the MCP server failed\" after Withings approval. The reference server implements both and connects cleanly.

## Changes

- **\`/token\` (authorization_code grant)** — response now includes \`refresh_token\`, sharing the same opaque \`mcpToken\` value as \`access_token\`. This project uses a single long-lived (30d) MCP token; refresh is a rotation operation rather than a TTL-extension step.
- **\`/token\` (refresh_token grant)** — look up the refresh token via the token store, rotate the stored \`mcp_token\` value to a fresh UUID, extend the expiry, return the new pair.
- **\`tokenStore.rotateToken()\`** — new method that updates the opaque token value in-place while preserving the encrypted Withings credentials and user mapping.
- **\`Cache-Control: no-store\` and \`Pragma: no-cache\`** on all \`/token\` responses (RFC 6749 §5.1).

No schema migration required — we reuse the existing \`mcp_token\` column.

## Test plan

- [ ] \`bun run typecheck\` passes
- [ ] \`curl -X POST -d 'grant_type=authorization_code&code=...&redirect_uri=...' https://withings-mcp.com/token\` response JSON includes a \`refresh_token\` field
- [ ] \`curl -X POST -d 'grant_type=refresh_token&refresh_token=...' https://withings-mcp.com/token\` rotates and returns a new pair (old token becomes invalid on subsequent MCP calls)
- [ ] Claude Desktop Connect completes and tools are listable

🤖 Generated with [Claude Code](https://claude.com/claude-code)