### PR TITLE
chore: log callback redirect target for OAuth debugging

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -397,6 +397,14 @@ export function createOAuthRouter(config: OAuthConfig) {
     redirectUrl.searchParams.append("code", authCode);
     redirectUrl.searchParams.append("state", session.state);
 
+    logger.info("Redirecting to client callback", {
+      host: redirectUrl.host,
+      pathname: redirectUrl.pathname,
+      hasCode: Boolean(redirectUrl.searchParams.get("code")),
+      hasState: Boolean(redirectUrl.searchParams.get("state")),
+      existingParams: Array.from(new URL(session.redirectUri).searchParams.keys()),
+    });
+
     return c.redirect(redirectUrl.toString());
   });
 


### PR DESCRIPTION
## Summary

Log what URL \`/callback\` is redirecting Claude.ai to — host, pathname, which params are present. No secrets in the log.

## Why

Current logs show this pattern on every Connect attempt:

\`\`\`
POST /register   200  (Claude.ai backend)
GET  /authorize  302  (browser → Withings)
GET  /callback   302  (browser, approved)
— NO POST /token ever happens —
\`\`\`

Claude.ai is supposed to POST \`/token\` right after receiving our callback redirect, but it's silently failing to do so — the MCP access token never gets exchanged. Most likely cause: our callback redirect URL is malformed in some subtle way (extra params, wrong path, double-appended state, etc.) and Claude.ai's callback page aborts.

This PR logs enough to see the redirect shape. After it deploys, retry Connect once and the logs will show exactly where we're sending Claude.

## Test plan

- [ ] Deploy, retry Claude Desktop Connect, share the new \`Redirecting to client callback\` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)