### PR TITLE
fix: issue client_secret on /register even for public clients

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -255,21 +255,27 @@ export function createOAuthRouter(config: OAuthConfig) {
             : undefined;
 
         const clientId = crypto.randomUUID();
+        const clientSecret = crypto.randomUUID();
         const issuedAt = Math.floor(Date.now() / 1000);
 
         await oauthStore.registerClient(clientId, {
           clientId,
+          clientSecret,
           redirectUris,
         });
 
         logger.info("OAuth client registered", { clientName });
 
-        // Return a full RFC 7591 client info document so the MCP client
-        // knows how to auth at /token (token_endpoint_auth_method: "none"
-        // for public clients like Claude Desktop) and which grant/response
-        // types are supported.
+        // Return a full RFC 7591 client info document. We issue both a
+        // client_id and a client_secret even though token_endpoint_auth_method
+        // is "none" — some orchestrators (notably Claude Desktop's) expect a
+        // client_secret in the registration response regardless of the
+        // declared auth method, and silently abandon the OAuth flow if it's
+        // missing. /token accepts "none" auth (no secret) or client_secret_post
+        // (secret echoed back).
         return c.json({
           client_id: clientId,
+          client_secret: clientSecret,
           client_id_issued_at: issuedAt,
           redirect_uris: redirectUris,
           token_endpoint_auth_method: "none",


### PR DESCRIPTION
## Summary

Include a generated \`client_secret\` in the dynamic client registration response. Matches the working reference (nutrition-mcp), which always returns one.

## Why

Every recent Claude Desktop Connect attempt shows this pattern in runtime logs:

\`\`\`
POST /register  200 python-httpx
GET  /authorize 302
GET  /callback  302 → claude.ai/api/mcp/auth_callback (with correct code + state)
— /token is never called —
POST /mcp       200 (using a cached token from a prior session)
\`\`\`

Claude.ai receives our callback redirect cleanly but never exchanges the code for a new token. Most plausible remaining cause: its OAuth orchestrator expects a \`client_secret\` in the \`/register\` response regardless of the declared \`token_endpoint_auth_method\`, and silently abandons the flow when the field is missing. The working reference has always returned one.

## Implementation

- Generate a per-client secret UUID in \`/register\`
- Store it alongside the client_id in \`registered_clients\` (the column already existed; we just weren't populating it)
- Return both \`client_id\` and \`client_secret\` in the response
- \`/token\` doesn't yet validate the secret, so this is purely additive

## Test plan

- [ ] \`curl -X POST -H 'content-type: application/json' -d '{\"client_name\":\"test\",\"redirect_uris\":[\"https://example.com\"]}' https://withings-mcp.com/register\` response includes \`client_secret\`
- [ ] Claude Desktop Connect triggers a fresh \`POST /token\` call after the callback (new log line: \`Processing token exchange request\`), and the connector becomes usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)