### PR TITLE
fix: minimal /register response body

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -256,7 +256,6 @@ export function createOAuthRouter(config: OAuthConfig) {
 
         const clientId = crypto.randomUUID();
         const clientSecret = crypto.randomUUID();
-        const issuedAt = Math.floor(Date.now() / 1000);
 
         await oauthStore.registerClient(clientId, {
           clientId,
@@ -266,22 +265,14 @@ export function createOAuthRouter(config: OAuthConfig) {
 
         logger.info("OAuth client registered", { clientName });
 
-        // Return a full RFC 7591 client info document. We issue both a
-        // client_id and a client_secret even though token_endpoint_auth_method
-        // is "none" — some orchestrators (notably Claude Desktop's) expect a
-        // client_secret in the registration response regardless of the
-        // declared auth method, and silently abandon the OAuth flow if it's
-        // missing. /token accepts "none" auth (no secret) or client_secret_post
-        // (secret echoed back).
+        // Minimal RFC 7591 response, matching the working nutrition-mcp
+        // reference exactly. Some OAuth orchestrators (including Claude's)
+        // strict-parse the response and silently abort if they encounter
+        // fields with values they don't like — keep the shape tiny.
         return c.json({
           client_id: clientId,
           client_secret: clientSecret,
-          client_id_issued_at: issuedAt,
           redirect_uris: redirectUris,
-          token_endpoint_auth_method: "none",
-          grant_types: ["authorization_code", "refresh_token"],
-          response_types: ["code"],
-          ...(clientName ? { client_name: clientName } : {}),
         });
       } catch (error) {
         logger.error("OAuth client registration failed", {


### PR DESCRIPTION
## Summary

Strip \`/register\` response down to the exact shape the working reference (nutrition-mcp) uses:

\`\`\`json
{
  \"client_id\": \"...\",
  \"client_secret\": \"...\",
  \"redirect_uris\": [...]
}
\`\`\`

Remove the extra RFC 7591 fields (\`client_id_issued_at\`, \`token_endpoint_auth_method\`, \`grant_types\`, \`response_types\`, \`client_name\`) I added earlier while trying to be more spec-compliant. Those apparently tripped up Claude's OAuth orchestrator: every recent Connect attempt shows \`/register → /authorize → /callback\` succeed and then \`/token\` silently never being called.

## Approach

Rather than chase every RFC 7591/8414/9728 detail in isolation, align to the exact response shape of a server that's confirmed working on the same stack.

## Test plan

- [ ] Claude Desktop Connect triggers a \`POST /token\` after callback (new \`Processing token exchange request\` log line)
- [ ] Connector becomes usable end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)