### PR TITLE
fix: match auth-server metadata exactly to working reference

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -193,7 +193,11 @@ export function createApp(config: ServerConfig) {
   // MCP endpoint — SDK transport handles GET, POST, DELETE internally
   app.all(MCP_ENDPOINT, authenticateBearer, handleMcp);
 
-  // OAuth Authorization Server Metadata (RFC 8414)
+  // OAuth Authorization Server Metadata (RFC 8414). Shape matches the
+  // working nutrition-mcp reference exactly. Extra/non-standard fields
+  // (scopes_supported, response_modes_supported, mcp_endpoint) appear to
+  // cause strict claude.ai validators to reject the document, producing
+  // step=start_error before OAuth can begin.
   app.get("/.well-known/oauth-authorization-server", (c) => {
     const baseUrl = getPublicBaseUrl(c);
     return c.json({
@@ -201,14 +205,10 @@ export function createApp(config: ServerConfig) {
       authorization_endpoint: `${baseUrl}/authorize`,
       token_endpoint: `${baseUrl}/token`,
       registration_endpoint: `${baseUrl}/register`,
-      scopes_supported: [],
-      response_types_supported: ["code"],
-      response_modes_supported: ["query"],
       grant_types_supported: ["authorization_code", "refresh_token"],
-      token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+      response_types_supported: ["code"],
       code_challenge_methods_supported: ["S256"],
-      // MCP-specific metadata
-      mcp_endpoint: `${baseUrl}${MCP_ENDPOINT}`,
+      token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
     });
   });
 


### PR DESCRIPTION
## Summary

Strip three fields from \`/.well-known/oauth-authorization-server\` that the working \`nutrition-mcp\` reference doesn't emit:

\`\`\`diff
- scopes_supported: []
- response_modes_supported: [\"query\"]
- mcp_endpoint: \"https://withings-mcp.com/mcp\"
\`\`\`

After this PR the document matches nutrition-mcp exactly, byte for byte.

## Why

The Connect URL in the latest failed attempt contained \`step=start_error\` — claude.ai's connector orchestrator is rejecting the server during its initial metadata validation, before any OAuth flow runs. Server logs confirm no \`/register\`, \`/authorize\`, \`/callback\`, or \`/token\` requests come in from Claude's backend on that attempt.

Side-by-side comparison of the two auth-server metadata documents pointed to these three extras as the only structural differences. Two are RFC 8414 optional-valid but not present in the reference; \`mcp_endpoint\` is a non-standard field.

## Test plan

- [ ] \`curl https://withings-mcp.com/.well-known/oauth-authorization-server\` matches the shape of \`nutrition-mcp\`'s equivalent (8 keys)
- [ ] Claude Desktop Connect gets past the initial validation; server logs now show \`POST /register\` after clicking Connect
- [ ] Full OAuth + MCP session initialization completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)