### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withings-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for Withings health data integration",
   "type": "module",
   "main": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/akutishevsky/withings-mcp",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -66,7 +66,7 @@ export const handleMcp = async (c: AppContext) => {
   });
 
   const server = new McpServer(
-    { name: "withings-mcp", version: "2.0.0" },
+    { name: "withings-mcp", version: "2.1.0" },
     { capabilities: { tools: {} } }
   );
   registerAllTools(server, mcpToken);


### PR DESCRIPTION
Version bump missed the #32 merge. Updates \`package.json\`, \`server.json\`, and the \`McpServer\` identity string in \`src/server/mcp-endpoints.ts\` to 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)