### PR TITLE
chore: set allowedHosts on MCP transport

### DIFF
--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -52,9 +52,15 @@ export const handleMcp = async (c: AppContext) => {
     return c.json({ error: "invalid_request" }, 400);
   }
 
-  // New session — create transport + server
+  // New session — create transport + server.
+  //
+  // allowedHosts silences the SDK's "binding to 0.0.0.0 without DNS rebinding
+  // protection" warning on startup and rejects any request whose Host header
+  // doesn't match. Behind DO App Platform + Cloudflare the Host forwarded to
+  // us is withings-mcp.com; no other value should ever reach this handler.
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: () => crypto.randomUUID(),
+    allowedHosts: ["withings-mcp.com"],
     onsessioninitialized: (id) => {
       sessions.set(id, { transport, mcpToken });
       logger.info("MCP session established");


### PR DESCRIPTION
Silences the SDK's DNS-rebinding warning by declaring the expected \`Host\` header value:

\`\`\`ts
allowedHosts: [\"withings-mcp.com\"]
\`\`\`

For a public, bearer-token-authenticated server DNS rebinding isn't a practical threat, but pinning the value both hides the warning from Runtime Logs and rejects any request whose \`Host\` was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)