### PR TITLE
fix: stop lapsed users being locked out of the token refresh flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ supabase/
     ├── 001_initial_schema.sql   # Database schema (tables, indexes)
     ├── 004_atomic_rate_limit.sql # Atomic rate limit PostgreSQL function
     ├── 005_pg_cron_cleanup.sql  # pg_cron jobs for expired record cleanup
-    └── 006_mcp_sessions.sql     # Persisted MCP sessions (survive restarts)
+    ├── 006_mcp_sessions.sql     # Persisted MCP sessions (survive restarts)
+    └── 007_token_rotation_grace.sql # previous_mcp_token grace window
 ```
 
 ### Logging
@@ -245,6 +246,17 @@ Uses **Supabase PostgreSQL** (@supabase/supabase-js) for persistent storage:
 - `rate_limits`: Rate limiting counters (dynamic window TTL)
 - `mcp_sessions`: MCP session ID → owning MCP token (30 day TTL, supabase/migrations/006_mcp_sessions.sql)
 - `check_rate_limit()`: Atomic PostgreSQL function for race-condition-free rate limiting (uses `SELECT ... FOR UPDATE`)
+
+**Token Rotation & Refresh** (src/auth/token-store.ts, src/auth/oauth.ts):
+
+The `refresh_token` grant rotates the opaque MCP token value. Rotation is **idempotent within a 60s grace window** (`ROTATION_GRACE_MS`), because a bare rotate strands clients:
+
+- `rotateToken()` records the superseded value in `previous_mcp_token` / `previous_token_expires_at`, and uses `UPDATE ... .select()` so it can tell whether a row actually matched. It returns `false` when a concurrent request already rotated — the caller must **not** hand out its candidate token, which was never written and would authenticate nothing.
+- `resolveRefreshToken()` resolves a presented token to the currently-live value: first by `mcp_token`, then by `previous_mcp_token` inside the grace window. `isReplay: true` means the caller is retrying a rotation that already happened, and must be given the existing token rather than triggering a second rotation.
+- Net effect: a client whose first refresh response was lost retries and gets the same token, instead of a terminal `invalid_grant` that would permanently strand it.
+- Grace applies **only** to the `/token` refresh path. `authenticateBearer` still accepts the live token only, so a superseded token cannot be used against `/mcp`.
+
+**Rate limiting is scoped per grant type** on `/token` (`rateLimit({ scope })`, identifier `${ip}:${path}:${grant_type}`). A client looping on a dead `refresh_token` used to exhaust the shared budget and then get 429ed on `authorization_code` — the only exchange that could repair it — locking the user out for the rest of the window. Hono caches the parsed form body, so the scope resolver reading it does not prevent the handler from parsing it again.
 
 **Token Store** (src/auth/token-store.ts):
 - Maps MCP tokens → Withings tokens (access, refresh, userId, expiry)

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -408,7 +408,20 @@ export function createOAuthRouter(config: OAuthConfig) {
   // Token endpoint - MCP client exchanges code for token, or refreshes it
   oauth.post(
     "/token",
-    rateLimit({ maxRequests: 100, windowMs: 3600000 }), // 100 requests per hour
+    rateLimit({
+      maxRequests: 100,
+      windowMs: 3600000, // 100 requests per hour, per grant type
+      // Budget per grant type, not per endpoint. A client stuck retrying a
+      // dead refresh_token used to burn the shared budget and then get 429ed
+      // on authorization_code — the one exchange that could have repaired it —
+      // leaving the user unable to reconnect for the rest of the window.
+      // Hono caches the parsed form body, so reading it here does not stop the
+      // handler below from parsing it again.
+      scope: async (c) => {
+        const body = await c.req.parseBody();
+        return typeof body.grant_type === "string" ? body.grant_type : "unknown";
+      },
+    }),
     async (c) => {
     const body = await c.req.parseBody();
     const grantType = body.grant_type;
@@ -422,23 +435,63 @@ export function createOAuthRouter(config: OAuthConfig) {
     if (grantType === "refresh_token") {
       const refreshToken = body.refresh_token as string;
       if (!refreshToken) {
-        return c.json({ error: "invalid_request" }, 400);
+        logger.warn("Token refresh failed: refresh_token parameter missing");
+        return c.json({
+          error: "invalid_request",
+          error_description: "refresh_token is required for this grant type",
+        }, 400);
       }
-      const existing = await tokenStore.getTokens(refreshToken);
-      if (!existing) {
-        return c.json({ error: "invalid_grant" }, 400);
+
+      const resolved = await tokenStore.resolveRefreshToken(refreshToken);
+      if (!resolved) {
+        logger.warn(
+          "Token refresh failed: refresh token is unknown, expired, or past the rotation grace window"
+        );
+        return c.json({
+          error: "invalid_grant",
+          error_description:
+            "refresh_token is no longer valid; re-authorize to obtain a new one",
+        }, 400);
       }
-      const newToken = crypto.randomUUID();
-      await tokenStore.rotateToken(refreshToken, newToken);
+
+      // Rotation is idempotent within the grace window. A client that retried
+      // because it never received (or never stored) the first response gets
+      // handed the same token the winning request was issued, instead of a
+      // terminal invalid_grant that would strand it permanently.
+      let issuedToken = resolved.currentToken;
+
+      if (!resolved.isReplay) {
+        const candidate = crypto.randomUUID();
+        const rotated = await tokenStore.rotateToken(refreshToken, candidate);
+
+        if (rotated) {
+          issuedToken = candidate;
+        } else {
+          // Lost a concurrent rotation race: `candidate` was never written, so
+          // returning it would hand the client a token that authenticates
+          // nothing. Re-resolve and return whatever the winner issued.
+          const winner = await tokenStore.resolveRefreshToken(refreshToken);
+          if (!winner) {
+            logger.warn(
+              "Token refresh failed: lost rotation race and the winning token is no longer resolvable"
+            );
+            return c.json({ error: "invalid_grant" }, 400);
+          }
+          issuedToken = winner.currentToken;
+          logger.info("Token refresh resolved a concurrent rotation race");
+        }
+      } else {
+        logger.info("Token refresh replayed within grace window");
+      }
 
       const MCP_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
       c.header("Cache-Control", "no-store");
       c.header("Pragma", "no-cache");
       return c.json({
-        access_token: newToken,
+        access_token: issuedToken,
         token_type: "Bearer",
         expires_in: MCP_TOKEN_TTL_SECONDS,
-        refresh_token: newToken,
+        refresh_token: issuedToken,
       });
     }
 

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -23,6 +23,12 @@ interface McpTokenRow {
 
 const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+// After a rotation the superseded token stays resolvable for this long, so a
+// retried or concurrent refresh is handed the same token the winning request
+// got instead of being told its grant is dead. Long enough to cover a client's
+// immediate retry, short enough that a rotated token is not usable in practice.
+const ROTATION_GRACE_MS = 60 * 1000; // 60 seconds
+
 class TokenStore {
   async init(): Promise<void> {
     // No initialization needed - Supabase client is initialized separately
@@ -129,24 +135,83 @@ class TokenStore {
     }
   }
 
+  // Resolve a token presented to the refresh_token grant.
+  //
+  // Returns the token value that is currently live for that row. `isReplay`
+  // means the caller presented a token that has already been rotated away but
+  // is still inside the grace window — a retried or concurrent refresh — and
+  // must be handed the existing token rather than triggering a second
+  // rotation, which would strand whichever client stored the first response.
+  async resolveRefreshToken(
+    presentedToken: string
+  ): Promise<{ currentToken: string; isReplay: boolean } | null> {
+    const supabase = getSupabaseClient();
+    const now = new Date().toISOString();
+
+    const { data: live } = await supabase
+      .from("mcp_tokens")
+      .select("mcp_token")
+      .eq("mcp_token", presentedToken)
+      .gt("expires_at", now)
+      .single();
+
+    if (live) {
+      return {
+        currentToken: (live as { mcp_token: string }).mcp_token,
+        isReplay: false,
+      };
+    }
+
+    const { data: superseded } = await supabase
+      .from("mcp_tokens")
+      .select("mcp_token")
+      .eq("previous_mcp_token", presentedToken)
+      .gt("previous_token_expires_at", now)
+      .gt("expires_at", now)
+      .single();
+
+    if (superseded) {
+      return {
+        currentToken: (superseded as { mcp_token: string }).mcp_token,
+        isReplay: true,
+      };
+    }
+
+    return null;
+  }
+
   // Rotate the MCP token (for OAuth refresh_token grant). Keeps all stored
   // Withings credentials and user mapping intact, just swaps the public-facing
   // token value and extends the TTL.
-  async rotateToken(oldToken: string, newToken: string): Promise<void> {
+  //
+  // Returns false if no row still carried `oldToken` — i.e. a concurrent
+  // request won the rotation race. The caller must not hand `newToken` to the
+  // client in that case: it was never written, so it would authenticate
+  // nothing. Use resolveRefreshToken() to recover the winner's value.
+  async rotateToken(oldToken: string, newToken: string): Promise<boolean> {
     const supabase = getSupabaseClient();
     const expiresAt = new Date(Date.now() + TTL_MS).toISOString();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("mcp_tokens")
       .update({
         mcp_token: newToken,
+        previous_mcp_token: oldToken,
+        previous_token_expires_at: new Date(
+          Date.now() + ROTATION_GRACE_MS
+        ).toISOString(),
         expires_at: expiresAt,
         updated_at: new Date().toISOString(),
       })
-      .eq("mcp_token", oldToken);
+      .eq("mcp_token", oldToken)
+      .select("mcp_token");
 
     if (error) {
       throw new Error(`Failed to rotate token: ${error.message}`);
+    }
+
+    if (!data || data.length === 0) {
+      return false;
     }
 
     // Sessions are owned by a token value, so they have to follow the
@@ -165,6 +230,8 @@ class TokenStore {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+
+    return true;
   }
 }
 

--- a/src/server/rate-limiter.ts
+++ b/src/server/rate-limiter.ts
@@ -7,6 +7,15 @@ const logger = createLogger({ component: "rate-limiter" });
 interface RateLimitConfig {
   maxRequests: number;
   windowMs: number;
+  /**
+   * Optional extra dimension appended to the `${ip}:${path}` identifier, giving
+   * distinct operations on one endpoint independent budgets.
+   *
+   * /token uses this to separate grant types: a client looping on a dead
+   * refresh_token must not be able to exhaust the authorization_code budget,
+   * because re-authorizing is the only thing that can actually repair it.
+   */
+  scope?: (c: Context) => Promise<string> | string;
 }
 
 class RateLimiter {
@@ -67,7 +76,20 @@ export function rateLimit(config: RateLimitConfig) {
                c.req.header("x-real-ip") ||
                "unknown";
 
-    const identifier = `${ip}:${c.req.path}`;
+    // A scope resolver reads the request body, so it must never be able to
+    // fail the request — an unparseable body just shares one bucket.
+    let scope = "";
+    if (config.scope) {
+      try {
+        scope = await config.scope(c);
+      } catch {
+        scope = "unknown";
+      }
+    }
+
+    const identifier = scope
+      ? `${ip}:${c.req.path}:${scope}`
+      : `${ip}:${c.req.path}`;
     const result = await rateLimiter.checkLimit(identifier, config);
 
     // Set rate limit headers
@@ -79,7 +101,7 @@ export function rateLimit(config: RateLimitConfig) {
       const retryAfter = Math.ceil((result.resetTime - Date.now()) / 1000);
       c.header("Retry-After", retryAfter.toString());
 
-      logger.warn("Rate limit exceeded", { ip, path: c.req.path });
+      logger.warn("Rate limit exceeded", { ip, path: c.req.path, scope });
 
       return c.json({
         error: "rate_limit_exceeded",

--- a/supabase/migrations/007_token_rotation_grace.sql
+++ b/supabase/migrations/007_token_rotation_grace.sql
@@ -1,0 +1,17 @@
+-- Rotation grace window for MCP tokens.
+--
+-- The refresh_token grant rotated with a bare UPDATE ... WHERE mcp_token = old,
+-- so a retried or concurrent refresh matched no row and received a terminal
+-- invalid_grant — permanently stranding a client whose first response was lost.
+-- Keeping the previous token resolvable for a short window makes refresh
+-- idempotent: a retry is handed the same token the winning request was issued.
+--
+-- Grace is deliberately short (60s in src/auth/token-store.ts). It only needs to
+-- cover a client's immediate retry, not a second refresh cycle.
+
+ALTER TABLE mcp_tokens
+  ADD COLUMN previous_mcp_token VARCHAR(255),
+  ADD COLUMN previous_token_expires_at TIMESTAMPTZ;
+
+-- Lookup path for resolving a presented token that was just rotated away
+CREATE INDEX idx_mcp_tokens_previous_mcp_token ON mcp_tokens(previous_mcp_token);


### PR DESCRIPTION
## Problem

Found while validating traffic after the session-persistence deploy. **Pre-existing, not caused by that deploy** — the affected rate-limit counter froze 4m36s *before* that deployment was even created, and `mcp_tokens.max(updated_at)` confirmed the new rotation code had never executed in production.

A client whose `refresh_token` stopped resolving:

1. `POST /mcp` → 401 → re-runs OAuth discovery
2. `POST /token` (`grant_type=refresh_token`) → **400 `invalid_grant`** (a branch that logged nothing)
3. retries hard — ~1.6 req/s observed — burning the shared 100/hour `/token` budget in ~60s
4. → **429 for the remaining ~59 minutes** of the fixed window

Because the budget was shared across grant types, the 429 *also* blocked `authorization_code` — the only exchange that could repair the situation. Steady state: ~1 minute of 400s, ~59 minutes of 429s, indefinitely. Observed clients never escalated to `/authorize` on their own.

The 429 **masked a terminal error behind a retryable-looking status**, so the client could never learn its grant was dead.

Scope: ~10–30 tokens lapse per day, and 4+ distinct clients hit `invalid_grant` in a single 11-minute sample. Recurring daily for whoever's 30-day token expired.

## Fixes

### 1. Rate limit `/token` per grant type

`rateLimit()` gains an optional `scope` dimension → identifier `${ip}:${path}:${grant_type}`. A dead refresh loop can no longer starve the `authorization_code` budget.

The resolver reads the form body before the handler does. Hono caches the parse (`request.bodyCache.formData`), so the handler still sees the full body — **verified end to end through a real Hono app**, including missing `grant_type`, wrong content-type, and empty body, all of which fall back to a single bucket rather than failing the request. This was the P0 regression risk: if the double-read broke, `/token` would break for *every* grant type.

### 2. Idempotent rotation (migration 007)

`rotateToken` records the superseded value in `previous_mcp_token` with a 60s expiry. `resolveRefreshToken` resolves a presented token via that column when it is no longer live, returning `isReplay: true`.

A client that retried because it never received or stored the first response now gets **the same token the winning request was issued**, instead of a terminal `invalid_grant`.

Grace applies **only** to the `/token` refresh path — `authenticateBearer` still accepts the live token only, so a superseded token cannot be used against `/mcp`.

### 3. A latent race found while writing the above 🔴

`rotateToken` was a bare `UPDATE ... WHERE mcp_token = old` with **no check on rows affected**. Two concurrent refreshes both generated a token and both "succeeded" — but the loser's `UPDATE` matched nothing, yet its freshly generated token was still returned to the client. **A token that had never been written and authenticated nothing.**

This is very likely how users entered the dead-refresh state in the first place, given the observed retry rates.

It now uses `.select()` to detect zero matched rows, returns `false`, and the caller re-resolves and returns whatever the winner issued. Session-ownership rotation is skipped on that path, since no rotation occurred.

### 4. Observability

Logging added to the two previously silent 400 branches (`oauth.ts:425/:429`) — distinguishing them in production previously required inferring from response latency. Plus `error_description` on both, matching the other 400 branches.

## ⚠️ Deploy order

**Apply `supabase/migrations/007_token_rotation_grace.sql` BEFORE deploying.**

The migration is purely additive and invisible to the currently-running code, so migration-first is safe. The reverse is **not**: the new code writes `previous_mcp_token` on every rotation, so deploying first would make every `refresh_token` grant return **500**.

## Test plan

- [x] `bun run typecheck` passes
- [x] Body double-read verified through a real Hono app (10 checks, incl. malformed input)
- [ ] Apply migration 007
- [ ] Deploy, then confirm: no 500s on `/token`, `Rate limit exceeded` warnings now carry a `scope` field, and `Token refresh replayed within grace window` / `resolved a concurrent rotation race` appear when clients retry

## Not addressed

The `/token` window is still **fixed** at 100/hour, so tripping one grant type's budget still costs up to 59 minutes for that grant type. With the root cause fixed, retry storms should stop — but a sliding window or shorter period would make it self-heal, and is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
