### PR TITLE
fix: sliding-window rate limiting so a tripped limit recovers in minutes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ supabase/
     ├── 004_atomic_rate_limit.sql # Atomic rate limit PostgreSQL function
     ├── 005_pg_cron_cleanup.sql  # pg_cron jobs for expired record cleanup
     ├── 006_mcp_sessions.sql     # Persisted MCP sessions (survive restarts)
-    └── 007_token_rotation_grace.sql # previous_mcp_token grace window
+    ├── 007_token_rotation_grace.sql # previous_mcp_token grace window
+    └── 008_sliding_window_rate_limit.sql # sliding-window check_rate_limit()
 ```
 
 ### Logging
@@ -257,6 +258,25 @@ The `refresh_token` grant rotates the opaque MCP token value. Rotation is **idem
 - Grace applies **only** to the `/token` refresh path. `authenticateBearer` still accepts the live token only, so a superseded token cannot be used against `/mcp`.
 
 **Rate limiting is scoped per grant type** on `/token` (`rateLimit({ scope })`, identifier `${ip}:${path}:${grant_type}`). A client looping on a dead `refresh_token` used to exhaust the shared budget and then get 429ed on `authorization_code` — the only exchange that could repair it — locking the user out for the rest of the window. Hono caches the parsed form body, so the scope resolver reading it does not prevent the handler from parsing it again.
+
+### Rate Limiting Algorithm
+
+`check_rate_limit()` is a **weighted two-window sliding counter** (supabase/migrations/008_sliding_window_rate_limit.sql), not a fixed window. Each identifier keeps a current and a previous count, and the trailing rate is estimated as:
+
+```
+estimate = previous_count * (time_left_in_current_window / window) + current_count
+```
+
+Capacity therefore returns *continuously* as the previous window ages out, instead of snapping back at a boundary. The fixed window it replaced meant a client that burned its budget in the first seconds stayed locked out for the whole remainder — up to ~59 minutes on `/token`.
+
+**The window length must stay short.** Smoothing lengthens the worst-case tail: a fully-burned window takes up to **two** window lengths to decay completely, versus one for a fixed window. Sliding windows are only an improvement when the window is small, which is why all three callers use 5 minutes. Do not raise them back to an hour.
+
+Current limits (all 5-minute sliding windows, keyed per IP + path, plus grant type on `/token`):
+- `/token`: 30 — a legitimate client needs 1–3 calls per authorization
+- `/authorize`: 15
+- `/register`: 5
+
+Measured recovery for `/token` after burning all 30 instantly: fully blocked for 5 minutes, then linear recovery (28 available at +5m30s, 17 at +7m30s, 4 at +9m59s), fully clear by 10 minutes. On the denied path the function returns the moment capacity actually becomes available, so `Retry-After` is honest rather than pointing at a raw window boundary.
 
 **Token Store** (src/auth/token-store.ts):
 - Maps MCP tokens → Withings tokens (access, refresh, userId, expiry)

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -240,7 +240,7 @@ export function createOAuthRouter(config: OAuthConfig) {
   // RFC 7591 — https://datatracker.ietf.org/doc/html/rfc7591
   oauth.post(
     "/register",
-    rateLimit({ maxRequests: 30, windowMs: 3600000 }), // 30 requests per hour
+    rateLimit({ maxRequests: 5, windowMs: 300000 }), // 5 per 5 min (sliding)
     async (c) => {
       try {
         const body = await c.req.json().catch(() => ({} as Record<string, unknown>));
@@ -289,7 +289,7 @@ export function createOAuthRouter(config: OAuthConfig) {
   // Authorization endpoint - MCP client starts here
   oauth.get(
     "/authorize",
-    rateLimit({ maxRequests: 60, windowMs: 3600000 }), // 60 requests per hour
+    rateLimit({ maxRequests: 15, windowMs: 300000 }), // 15 per 5 min (sliding)
     async (c) => {
     const responseType = c.req.query("response_type");
     const clientId = c.req.query("client_id");
@@ -409,8 +409,13 @@ export function createOAuthRouter(config: OAuthConfig) {
   oauth.post(
     "/token",
     rateLimit({
-      maxRequests: 100,
-      windowMs: 3600000, // 100 requests per hour, per grant type
+      maxRequests: 30,
+      // 30 per 5 minutes, per grant type, on a sliding window. Short window is
+      // deliberate: the limiter smooths capacity across two windows, so a long
+      // one would take up to two hours to fully decay. A legitimate client
+      // needs 1-3 calls per authorization, so 30 is ample headroom while a
+      // stuck client recovers in minutes rather than the better part of a day.
+      windowMs: 300000,
       // Budget per grant type, not per endpoint. A client stuck retrying a
       // dead refresh_token used to burn the shared budget and then get 429ed
       // on authorization_code — the one exchange that could have repaired it —

--- a/supabase/migrations/008_sliding_window_rate_limit.sql
+++ b/supabase/migrations/008_sliding_window_rate_limit.sql
@@ -1,0 +1,132 @@
+-- Sliding-window rate limiting (weighted two-window counter).
+--
+-- The fixed-window implementation in 004 only reset at a hard boundary, so a
+-- client that burned its budget in the first seconds of a window stayed locked
+-- out for the entire remainder of it. On /token that meant up to ~59 minutes,
+-- long enough that a user whose refresh grant had died could not re-authorize.
+--
+-- This keeps two counters per identifier — the current window and the one
+-- before it — and estimates the trailing-window rate by weighting the previous
+-- count by how much of it still falls inside the trailing window:
+--
+--   estimate = previous_count * (time_left_in_current_window / window) + current_count
+--
+-- Capacity therefore returns continuously as the previous window ages out
+-- rather than all at once at a boundary, and storage stays at one row per
+-- identifier (a true sliding log would need a timestamp per request).
+--
+-- NOTE: this smoothing lengthens the worst-case tail — a fully-burned window
+-- takes up to TWO window lengths to decay completely, versus one for a fixed
+-- window. It is only an improvement if the window is short. The callers in
+-- src/auth/oauth.ts were moved to 5-minute windows accordingly; do not raise
+-- them back to an hour without revisiting this.
+
+ALTER TABLE rate_limits
+  ADD COLUMN previous_count INTEGER NOT NULL DEFAULT 0;
+
+-- Signature is unchanged so src/server/rate-limiter.ts needs no rewrite.
+-- `request_count` returns the ceiling of the weighted estimate (so
+-- X-RateLimit-Remaining stays meaningful) and, on the denied path,
+-- `reset_time` returns the moment capacity actually becomes available rather
+-- than the raw window boundary — an honest Retry-After was the whole point.
+CREATE OR REPLACE FUNCTION check_rate_limit(
+  p_identifier VARCHAR(512),
+  p_max_requests INTEGER,
+  p_window_ms BIGINT
+)
+RETURNS TABLE(allowed BOOLEAN, request_count INTEGER, reset_time TIMESTAMPTZ)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_now        TIMESTAMPTZ := NOW();
+  v_window     INTERVAL := (p_window_ms || ' milliseconds')::INTERVAL;
+  v_reset_time TIMESTAMPTZ;
+  v_current    INTEGER;
+  v_previous   INTEGER;
+  v_weight     NUMERIC;
+  v_estimate   NUMERIC;
+  v_retry_at   TIMESTAMPTZ;
+BEGIN
+  SELECT rl.request_count, rl.previous_count, rl.reset_time
+  INTO v_current, v_previous, v_reset_time
+  FROM rate_limits rl
+  WHERE rl.identifier = p_identifier
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    v_reset_time := v_now + v_window;
+    INSERT INTO rate_limits (identifier, request_count, previous_count, reset_time, updated_at)
+    VALUES (p_identifier, 1, 0, v_reset_time, v_now)
+    ON CONFLICT (identifier) DO UPDATE
+    SET request_count = 1, previous_count = 0, reset_time = v_reset_time, updated_at = v_now;
+
+    RETURN QUERY SELECT TRUE, 1, v_reset_time;
+    RETURN;
+  END IF;
+
+  -- Roll the windows forward if the stored one has ended.
+  IF v_now >= v_reset_time THEN
+    IF v_now < v_reset_time + v_window THEN
+      -- Exactly one window elapsed: the current count becomes the previous one.
+      v_previous := v_current;
+      v_current := 0;
+      v_reset_time := v_reset_time + v_window;
+    ELSE
+      -- More than one window elapsed: nothing left to carry.
+      v_previous := 0;
+      v_current := 0;
+      v_reset_time := v_now + v_window;
+    END IF;
+  END IF;
+
+  -- Fraction of the previous window still inside the trailing window.
+  v_weight := LEAST(1.0, GREATEST(0.0,
+    EXTRACT(EPOCH FROM (v_reset_time - v_now)) * 1000.0 / p_window_ms));
+  v_estimate := (v_previous * v_weight) + v_current;
+
+  IF v_estimate >= p_max_requests THEN
+    -- Earliest moment the estimate drops below the limit. Solving
+    --   previous * (reset - t)/window + current < max
+    -- for t gives t > reset - window * (max - current)/previous.
+    -- NB: interval only multiplies by double precision in Postgres — there is
+    -- no interval * numeric operator — hence the explicit casts below.
+    IF v_current >= p_max_requests THEN
+      -- The current window alone is at the limit; it cannot decay until the
+      -- window rolls, after which the same count decays as `previous`.
+      v_retry_at := (v_reset_time + v_window)
+                    - v_window * (p_max_requests::DOUBLE PRECISION
+                                  / GREATEST(v_current, 1)::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_reset_time);
+    ELSIF v_previous > 0 THEN
+      v_retry_at := v_reset_time
+                    - v_window * ((p_max_requests - v_current)::DOUBLE PRECISION
+                                  / v_previous::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_now);
+    ELSE
+      v_retry_at := v_reset_time;
+    END IF;
+
+    -- Persist any window roll so the next call does not recompute it.
+    UPDATE rate_limits rl
+    SET request_count = v_current,
+        previous_count = v_previous,
+        reset_time = v_reset_time,
+        updated_at = v_now
+    WHERE rl.identifier = p_identifier;
+
+    RETURN QUERY SELECT FALSE, CEIL(v_estimate)::INTEGER, v_retry_at;
+    RETURN;
+  END IF;
+
+  v_current := v_current + 1;
+
+  UPDATE rate_limits rl
+  SET request_count = v_current,
+      previous_count = v_previous,
+      reset_time = v_reset_time,
+      updated_at = v_now
+  WHERE rl.identifier = p_identifier;
+
+  RETURN QUERY SELECT TRUE, CEIL(v_estimate)::INTEGER + 1, v_reset_time;
+END;
+$$;


### PR DESCRIPTION
Follow-up to #37, which fixed the token-refresh lockout but deliberately left the limiter's fixed window alone.

## Problem

`check_rate_limit()` was a fixed window: burn the budget in the first seconds and you stay locked out for the *entire* remainder — up to ~59 minutes on `/token`. Combined with the shared-across-grant-types budget that #37 fixed, that was long enough to stop a user whose refresh grant had died from re-authorizing at all.

## Approach

A weighted two-window sliding counter:

```
estimate = previous_count * (time_left_in_current_window / window) + current_count
```

Capacity returns *continuously* as the previous window ages out, instead of snapping back at a boundary. Storage stays at one row per identifier — a true sliding log would need a timestamp per request.

### The window length had to shrink

This is the non-obvious part. Smoothing **lengthens** the worst-case tail: a fully-burned window takes up to **two** window lengths to decay completely, versus one for a fixed window. Sliding + the existing 1-hour windows would have been *strictly worse* than what it replaced.

So all three callers move to 5-minute windows:

| Endpoint | Was | Now |
|---|---|---|
| `/token` | 100 / 1h | **30 / 5m** (per grant type) |
| `/authorize` | 60 / 1h | **15 / 5m** |
| `/register` | 30 / 1h | **5 / 5m** |

A legitimate client needs 1–3 `/token` calls per authorization, so 30 is ample headroom.

`Retry-After` is now honest too: on the denied path the function returns the moment capacity actually becomes available rather than the raw window boundary. A misleading retry signal was the original bug.

## Verification

Executed against **real Postgres** using a throwaway table and function name with an injectable clock — production `check_rate_limit` and `rate_limits` were never touched, and both probe objects were dropped and their absence confirmed afterwards.

Burning all 30 instantly against a 30-per-5-minute limit:

| Time after burn | Allowed? | Est. count |
|---|---|---|
| requests 1–30 | ✅ | 30 |
| requests 31–32 | ❌ | 30 |
| +1m, +4m59s | ❌ | 30 |
| +5m00s (boundary) | ❌ | 30 |
| **+5m30s** | ✅ | 28 |
| +7m30s | ✅ | 17 |
| +9m59s | ✅ | 4 |

The limit still enforces at exactly 30, and recovery is linear from 5→10 minutes instead of a 60-minute cliff. `Retry-After` said 00:05:00 and +5m30s was indeed allowed.

My first test attempt reported 35/35 allowed — that was the *test* being wrong, not the function: every `LATERAL` call in a single statement shares one MVCC snapshot, so none saw the others' increments. Re-run as a loop where each call is its own command, it behaved correctly.

## Incidental fix

Postgres has no `interval * numeric` operator, only `interval * double precision`. The retry-time arithmetic produced numeric, so **every denied request would have raised** at runtime. Caught by review before testing; explicit casts added.

## Deploy order

**Apply `008_sliding_window_rate_limit.sql` before deploying**, keeping the established habit.

Worth noting that either order is genuinely safe here: the function signature is unchanged and `previous_count` defaults to 0, so the new function behaves identically to the old one until a window rolls — by which time the code will be out.

## Test plan

- [x] `bun run typecheck`
- [x] Sliding-window behaviour verified against real Postgres (see table)
- [x] Probe objects cleaned up; production function/table confirmed untouched
- [ ] Apply migration 008
- [ ] Deploy, then confirm `Rate limit exceeded` warnings carry sane `Retry-After` values and no `check_rate_limit` errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
