### PR TITLE
fix: clamp stale rate-limit reset_time left over from a longer window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ supabase/
     ├── 005_pg_cron_cleanup.sql  # pg_cron jobs for expired record cleanup
     ├── 006_mcp_sessions.sql     # Persisted MCP sessions (survive restarts)
     ├── 007_token_rotation_grace.sql # previous_mcp_token grace window
-    └── 008_sliding_window_rate_limit.sql # sliding-window check_rate_limit()
+    ├── 008_sliding_window_rate_limit.sql # sliding-window check_rate_limit()
+    └── 009_rate_limit_window_clamp.sql   # clamp stale reset_time from a longer window
 ```
 
 ### Logging
@@ -268,6 +269,8 @@ estimate = previous_count * (time_left_in_current_window / window) + current_cou
 ```
 
 Capacity therefore returns *continuously* as the previous window ages out, instead of snapping back at a boundary. The fixed window it replaced meant a client that burned its budget in the first seconds stayed locked out for the whole remainder — up to ~59 minutes on `/token`.
+
+The function **clamps a `reset_time` that sits further out than one window** (migration 009). Without that, a row written under a longer window keeps its distant boundary forever, the weight pins at 1.0, the window never rolls and capacity never decays — which reintroduces exactly the long lockout this design exists to prevent. The clamp makes window length safe to reconfigure.
 
 **The window length must stay short.** Smoothing lengthens the worst-case tail: a fully-burned window takes up to **two** window lengths to decay completely, versus one for a fixed window. Sliding windows are only an improvement when the window is small, which is why all three callers use 5 minutes. Do not raise them back to an hour.
 

--- a/supabase/migrations/009_rate_limit_window_clamp.sql
+++ b/supabase/migrations/009_rate_limit_window_clamp.sql
@@ -1,0 +1,127 @@
+-- Clamp a stale reset_time that sits further out than one window.
+--
+-- 008 only recomputes reset_time when the stored window has already ended, so a
+-- row written under a LONGER window keeps its distant boundary indefinitely.
+-- Observed in production immediately after 008 shipped: rows created by the old
+-- 1-hour config still carried reset_time ~40 minutes out while the new config
+-- passes a 5-minute window, so
+--
+--   weight = (reset_time - now) / window = 2384s / 300s = 7.9 -> clamps to 1.0
+--
+-- pinned the weight at 1.0 permanently. The previous count never decayed, the
+-- window never rolled, and Retry-After came back as ~43 minutes — exactly the
+-- long lockout 008 exists to prevent.
+--
+-- Pulling the boundary back into range makes the function self-correcting: it
+-- no longer assumes stored rows were written under the window currently being
+-- passed in, so windows can be reconfigured freely.
+--
+-- No data migration needed; affected rows fix themselves on their next request.
+
+CREATE OR REPLACE FUNCTION check_rate_limit(
+  p_identifier VARCHAR(512),
+  p_max_requests INTEGER,
+  p_window_ms BIGINT
+)
+RETURNS TABLE(allowed BOOLEAN, request_count INTEGER, reset_time TIMESTAMPTZ)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_now        TIMESTAMPTZ := NOW();
+  v_window     INTERVAL := (p_window_ms || ' milliseconds')::INTERVAL;
+  v_reset_time TIMESTAMPTZ;
+  v_current    INTEGER;
+  v_previous   INTEGER;
+  v_weight     NUMERIC;
+  v_estimate   NUMERIC;
+  v_retry_at   TIMESTAMPTZ;
+BEGIN
+  SELECT rl.request_count, rl.previous_count, rl.reset_time
+  INTO v_current, v_previous, v_reset_time
+  FROM rate_limits rl
+  WHERE rl.identifier = p_identifier
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    v_reset_time := v_now + v_window;
+    INSERT INTO rate_limits (identifier, request_count, previous_count, reset_time, updated_at)
+    VALUES (p_identifier, 1, 0, v_reset_time, v_now)
+    ON CONFLICT (identifier) DO UPDATE
+    SET request_count = 1, previous_count = 0, reset_time = v_reset_time, updated_at = v_now;
+
+    RETURN QUERY SELECT TRUE, 1, v_reset_time;
+    RETURN;
+  END IF;
+
+  -- Roll the windows forward if the stored one has ended.
+  IF v_now >= v_reset_time THEN
+    IF v_now < v_reset_time + v_window THEN
+      -- Exactly one window elapsed: the current count becomes the previous one.
+      v_previous := v_current;
+      v_current := 0;
+      v_reset_time := v_reset_time + v_window;
+    ELSE
+      -- More than one window elapsed: nothing left to carry.
+      v_previous := 0;
+      v_current := 0;
+      v_reset_time := v_now + v_window;
+    END IF;
+  END IF;
+
+  -- Stale boundary from a longer window: pull it back so the weight below
+  -- cannot pin at 1.0 forever. See the header comment.
+  IF v_reset_time > v_now + v_window THEN
+    v_reset_time := v_now + v_window;
+  END IF;
+
+  -- Fraction of the previous window still inside the trailing window.
+  v_weight := LEAST(1.0, GREATEST(0.0,
+    EXTRACT(EPOCH FROM (v_reset_time - v_now)) * 1000.0 / p_window_ms));
+  v_estimate := (v_previous * v_weight) + v_current;
+
+  IF v_estimate >= p_max_requests THEN
+    -- Earliest moment the estimate drops below the limit. Solving
+    --   previous * (reset - t)/window + current < max
+    -- for t gives t > reset - window * (max - current)/previous.
+    -- NB: interval only multiplies by double precision in Postgres — there is
+    -- no interval * numeric operator — hence the explicit casts below.
+    IF v_current >= p_max_requests THEN
+      -- The current window alone is at the limit; it cannot decay until the
+      -- window rolls, after which the same count decays as `previous`.
+      v_retry_at := (v_reset_time + v_window)
+                    - v_window * (p_max_requests::DOUBLE PRECISION
+                                  / GREATEST(v_current, 1)::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_reset_time);
+    ELSIF v_previous > 0 THEN
+      v_retry_at := v_reset_time
+                    - v_window * ((p_max_requests - v_current)::DOUBLE PRECISION
+                                  / v_previous::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_now);
+    ELSE
+      v_retry_at := v_reset_time;
+    END IF;
+
+    -- Persist any window roll or clamp so the next call does not recompute it.
+    UPDATE rate_limits rl
+    SET request_count = v_current,
+        previous_count = v_previous,
+        reset_time = v_reset_time,
+        updated_at = v_now
+    WHERE rl.identifier = p_identifier;
+
+    RETURN QUERY SELECT FALSE, CEIL(v_estimate)::INTEGER, v_retry_at;
+    RETURN;
+  END IF;
+
+  v_current := v_current + 1;
+
+  UPDATE rate_limits rl
+  SET request_count = v_current,
+      previous_count = v_previous,
+      reset_time = v_reset_time,
+      updated_at = v_now
+  WHERE rl.identifier = p_identifier;
+
+  RETURN QUERY SELECT TRUE, CEIL(v_estimate)::INTEGER + 1, v_reset_time;
+END;
+$$;


### PR DESCRIPTION
Follow-up to #38, found in production minutes after it shipped.

## Problem

#38 only recomputes `reset_time` once the stored window has **ended**. Rows written by the old 1-hour config therefore kept a boundary ~40 minutes out, while the new config passes a 5-minute window:

```
weight = (reset_time - now) / window = 2384s / 300s = 7.9  ->  clamps to 1.0
```

Pinned at `1.0` permanently: the previous count never decays, the window never rolls, and `Retry-After` comes back as **~43 minutes** — precisely the long lockout #38 was written to eliminate.

Confirmed live: `rate_limits` rows showed `window_ends_in_secs` of 2384, 2570, 2336, 2746 — 40–46 minutes, against a 5-minute configured window.

## Fix

Pull the boundary back into range when it sits further out than one window:

```sql
IF v_reset_time > v_now + v_window THEN
  v_reset_time := v_now + v_window;
END IF;
```

The function no longer assumes stored rows were written under the window currently being passed in, so window lengths become safe to reconfigure.

## Verification

Against **real Postgres**, using a throwaway table and function (both dropped afterwards, absence confirmed; production `check_rate_limit` and `rate_limits` untouched).

**A/B on the exact production row** — count 82, boundary 40 min out, queried with a 5-minute window, guard toggled:

| Variant | Allowed | Retry-After |
|---|---|---|
| Without guard (current prod) | ❌ | **43.2 min** |
| With guard (009) | ❌ | **8.2 min** |

The 43.2 figure matches what production actually returned, which confirms the diagnosis rather than just the fix.

**Regression over #38's normal path — byte-identical:**

| Step | Allowed | Est. |
|---|---|---|
| burn #30 | ✅ | 30 |
| burn #31, #32 | ❌ | 30 |
| +1m00s | ❌ | 30 |
| +5m00s | ❌ | 30 |
| +5m30s | ✅ | 28 |
| +7m30s | ✅ | 17 |
| +9m59s | ✅ | 4 |

The guard is a no-op unless the boundary is stale.

## Deploy

**Apply `009_rate_limit_window_clamp.sql`.** It is a `CREATE OR REPLACE FUNCTION` only — no schema change, no data migration. Affected rows self-correct on their next request.

No application code changes, so no redeploy is strictly required; the fix takes effect the moment the migration lands.

## Test plan

- [x] `bun run typecheck`
- [x] A/B against the reproduced production row
- [x] Regression over #38's recovery curve
- [x] Probe objects cleaned up; production function/table confirmed untouched
- [ ] Apply migration 009
- [ ] Confirm `rate_limits.reset_time` values fall within ~5 minutes as rows are touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
