### PR TITLE
test: add a test suite, with regression coverage for the shipped bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    # Real Postgres so the SQL tests actually exercise the migrations and
+    # plpgsql. The rate-limit bugs this suite exists to catch only reproduce
+    # against a real server.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun test
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      # Actions pinned to full commit SHAs: a mutable tag can be repointed
+      # at arbitrary code by anyone who can push to the action's repo.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
-      - run: bun install --frozen-lockfile
+      # --ignore-scripts: nothing here needs postinstall hooks, and running
+      # them would execute third-party code during CI installs.
+      - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun run typecheck
       - run: bun test
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ supabase/
     ├── 005_pg_cron_cleanup.sql  # pg_cron jobs for expired record cleanup
     ├── 006_mcp_sessions.sql     # Persisted MCP sessions (survive restarts)
     ├── 007_token_rotation_grace.sql # previous_mcp_token grace window
-    └── 008_sliding_window_rate_limit.sql # sliding-window check_rate_limit()
+    ├── 008_sliding_window_rate_limit.sql # sliding-window check_rate_limit()
+    └── 009_rate_limit_window_clamp.sql   # clamp stale reset_time from a longer window
 ```
 
 ### Logging
@@ -268,6 +269,8 @@ estimate = previous_count * (time_left_in_current_window / window) + current_cou
 ```
 
 Capacity therefore returns *continuously* as the previous window ages out, instead of snapping back at a boundary. The fixed window it replaced meant a client that burned its budget in the first seconds stayed locked out for the whole remainder — up to ~59 minutes on `/token`.
+
+The function **clamps a `reset_time` that sits further out than one window** (migration 009). Without that, a row written under a longer window keeps its distant boundary forever, the weight pins at 1.0, the window never rolls and capacity never decays — which reintroduces exactly the long lockout this design exists to prevent. The clamp makes window length safe to reconfigure.
 
 **The window length must stay short.** Smoothing lengthens the worst-case tail: a fully-burned window takes up to **two** window lengths to decay completely, versus one for a fixed window. Sliding windows are only an improvement when the window is small, which is why all three callers use 5 minutes. Do not raise them back to an hour.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "dev": "bun --hot src/index.ts",
     "build": "bun build src/index.ts --target bun --outdir build",
     "typecheck": "tsc --noEmit",
-    "generate-secret": "bun -e \"console.log('ENCRYPTION_SECRET=' + require('crypto').randomBytes(32).toString('hex'))\""
+    "generate-secret": "bun -e \"console.log('ENCRYPTION_SECRET=' + require('crypto').randomBytes(32).toString('hex'))\"",
+    "test": "bun test",
+    "test:db": "TEST_DATABASE_URL=${TEST_DATABASE_URL:-postgres://postgres:postgres@localhost:5432/postgres} bun test"
   },
   "keywords": [
     "mcp",

--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -83,7 +83,10 @@ async function rehydrateSession(
   mcpToken: string
 ): Promise<Session> {
   const transport = new WebStandardStreamableHTTPServerTransport({
-    // Stateless mode passes `undefined` rather than the id, so close over it.
+    // Close over the id rather than taking the callback argument: this SDK
+    // passes `this.sessionId` (which we assign below, so it is correct today),
+    // but a stateless transport has no session of its own and a future version
+    // could reasonably pass `undefined` here.
     onsessionclosed: () => {
       sessions.delete(sessionId);
       void sessionStore.delete(sessionId).catch((err) => {

--- a/supabase/migrations/009_rate_limit_window_clamp.sql
+++ b/supabase/migrations/009_rate_limit_window_clamp.sql
@@ -1,0 +1,127 @@
+-- Clamp a stale reset_time that sits further out than one window.
+--
+-- 008 only recomputes reset_time when the stored window has already ended, so a
+-- row written under a LONGER window keeps its distant boundary indefinitely.
+-- Observed in production immediately after 008 shipped: rows created by the old
+-- 1-hour config still carried reset_time ~40 minutes out while the new config
+-- passes a 5-minute window, so
+--
+--   weight = (reset_time - now) / window = 2384s / 300s = 7.9 -> clamps to 1.0
+--
+-- pinned the weight at 1.0 permanently. The previous count never decayed, the
+-- window never rolled, and Retry-After came back as ~43 minutes — exactly the
+-- long lockout 008 exists to prevent.
+--
+-- Pulling the boundary back into range makes the function self-correcting: it
+-- no longer assumes stored rows were written under the window currently being
+-- passed in, so windows can be reconfigured freely.
+--
+-- No data migration needed; affected rows fix themselves on their next request.
+
+CREATE OR REPLACE FUNCTION check_rate_limit(
+  p_identifier VARCHAR(512),
+  p_max_requests INTEGER,
+  p_window_ms BIGINT
+)
+RETURNS TABLE(allowed BOOLEAN, request_count INTEGER, reset_time TIMESTAMPTZ)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_now        TIMESTAMPTZ := NOW();
+  v_window     INTERVAL := (p_window_ms || ' milliseconds')::INTERVAL;
+  v_reset_time TIMESTAMPTZ;
+  v_current    INTEGER;
+  v_previous   INTEGER;
+  v_weight     NUMERIC;
+  v_estimate   NUMERIC;
+  v_retry_at   TIMESTAMPTZ;
+BEGIN
+  SELECT rl.request_count, rl.previous_count, rl.reset_time
+  INTO v_current, v_previous, v_reset_time
+  FROM rate_limits rl
+  WHERE rl.identifier = p_identifier
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    v_reset_time := v_now + v_window;
+    INSERT INTO rate_limits (identifier, request_count, previous_count, reset_time, updated_at)
+    VALUES (p_identifier, 1, 0, v_reset_time, v_now)
+    ON CONFLICT (identifier) DO UPDATE
+    SET request_count = 1, previous_count = 0, reset_time = v_reset_time, updated_at = v_now;
+
+    RETURN QUERY SELECT TRUE, 1, v_reset_time;
+    RETURN;
+  END IF;
+
+  -- Roll the windows forward if the stored one has ended.
+  IF v_now >= v_reset_time THEN
+    IF v_now < v_reset_time + v_window THEN
+      -- Exactly one window elapsed: the current count becomes the previous one.
+      v_previous := v_current;
+      v_current := 0;
+      v_reset_time := v_reset_time + v_window;
+    ELSE
+      -- More than one window elapsed: nothing left to carry.
+      v_previous := 0;
+      v_current := 0;
+      v_reset_time := v_now + v_window;
+    END IF;
+  END IF;
+
+  -- Stale boundary from a longer window: pull it back so the weight below
+  -- cannot pin at 1.0 forever. See the header comment.
+  IF v_reset_time > v_now + v_window THEN
+    v_reset_time := v_now + v_window;
+  END IF;
+
+  -- Fraction of the previous window still inside the trailing window.
+  v_weight := LEAST(1.0, GREATEST(0.0,
+    EXTRACT(EPOCH FROM (v_reset_time - v_now)) * 1000.0 / p_window_ms));
+  v_estimate := (v_previous * v_weight) + v_current;
+
+  IF v_estimate >= p_max_requests THEN
+    -- Earliest moment the estimate drops below the limit. Solving
+    --   previous * (reset - t)/window + current < max
+    -- for t gives t > reset - window * (max - current)/previous.
+    -- NB: interval only multiplies by double precision in Postgres — there is
+    -- no interval * numeric operator — hence the explicit casts below.
+    IF v_current >= p_max_requests THEN
+      -- The current window alone is at the limit; it cannot decay until the
+      -- window rolls, after which the same count decays as `previous`.
+      v_retry_at := (v_reset_time + v_window)
+                    - v_window * (p_max_requests::DOUBLE PRECISION
+                                  / GREATEST(v_current, 1)::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_reset_time);
+    ELSIF v_previous > 0 THEN
+      v_retry_at := v_reset_time
+                    - v_window * ((p_max_requests - v_current)::DOUBLE PRECISION
+                                  / v_previous::DOUBLE PRECISION);
+      v_retry_at := GREATEST(v_retry_at, v_now);
+    ELSE
+      v_retry_at := v_reset_time;
+    END IF;
+
+    -- Persist any window roll or clamp so the next call does not recompute it.
+    UPDATE rate_limits rl
+    SET request_count = v_current,
+        previous_count = v_previous,
+        reset_time = v_reset_time,
+        updated_at = v_now
+    WHERE rl.identifier = p_identifier;
+
+    RETURN QUERY SELECT FALSE, CEIL(v_estimate)::INTEGER, v_retry_at;
+    RETURN;
+  END IF;
+
+  v_current := v_current + 1;
+
+  UPDATE rate_limits rl
+  SET request_count = v_current,
+      previous_count = v_previous,
+      reset_time = v_reset_time,
+      updated_at = v_now
+  WHERE rl.identifier = p_identifier;
+
+  RETURN QUERY SELECT TRUE, CEIL(v_estimate)::INTEGER + 1, v_reset_time;
+END;
+$$;

--- a/tests/encryption.test.ts
+++ b/tests/encryption.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for src/utils/encryption.ts (AES-256-GCM at-rest encryption).
+ *
+ * ENCRYPTION_SECRET must exist before the module is used, and the module reads
+ * it through Bun.env (an alias of process.env) on every call, so it is set here
+ * at module scope — before the import below is evaluated at runtime.
+ */
+import { describe, test, expect } from "bun:test";
+import { Buffer } from "node:buffer";
+
+// Throwaway test-only secret. 64 hex chars, satisfying the >= 32 char minimum.
+const TEST_SECRET =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+process.env.ENCRYPTION_SECRET = TEST_SECRET;
+
+const { encrypt, decrypt } = await import("../src/utils/encryption.js");
+
+// salt(32) + iv(16) + tag(16) = 64 bytes of header before the ciphertext.
+const HEADER_BYTES = 64;
+
+describe("encrypt / decrypt round trip", () => {
+  test.each([
+    ["ascii", "hello world"],
+    ["a token-shaped string", "wth_1a2b3c4d5e6f7g8h9i0j"],
+    ["json", JSON.stringify({ access_token: "abc", userid: 12345 })],
+    ["unicode", "héllo wörld — 世界 🎉 Ω ñ"],
+    ["emoji only", "🔐🧬🩺"],
+    ["whitespace", "  \n\t  "],
+    ["empty string", ""],
+  ])("round trips %s", (_label, plaintext) => {
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  test("round trips a long string", () => {
+    const long = "withings-".repeat(20000); // ~180 KB
+    const ciphertext = encrypt(long);
+    expect(decrypt(ciphertext)).toBe(long);
+    expect(decrypt(ciphertext).length).toBe(long.length);
+  });
+
+  test("ciphertext is base64 and is not the plaintext", () => {
+    const plaintext = "super-secret-refresh-token";
+    const ciphertext = encrypt(plaintext);
+
+    expect(ciphertext).not.toContain(plaintext);
+    expect(ciphertext).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    // Decoding and re-encoding is lossless => it really is valid base64.
+    expect(Buffer.from(ciphertext, "base64").toString("base64")).toBe(ciphertext);
+  });
+
+  test("output carries the 64-byte salt+iv+tag header ahead of the ciphertext", () => {
+    const raw = Buffer.from(encrypt("abc"), "base64");
+    expect(raw.length).toBe(HEADER_BYTES + 3); // GCM is a stream mode: no padding
+    expect(Buffer.from(encrypt(""), "base64").length).toBe(HEADER_BYTES);
+  });
+});
+
+describe("randomness", () => {
+  test("the same plaintext encrypts to different ciphertexts, both decryptable", () => {
+    const plaintext = "identical input";
+    const a = encrypt(plaintext);
+    const b = encrypt(plaintext);
+
+    expect(a).not.toBe(b);
+    expect(decrypt(a)).toBe(plaintext);
+    expect(decrypt(b)).toBe(plaintext);
+  });
+
+  test("salt and IV differ across operations", () => {
+    const a = Buffer.from(encrypt("x"), "base64");
+    const b = Buffer.from(encrypt("x"), "base64");
+
+    expect(a.subarray(0, 32).equals(b.subarray(0, 32))).toBe(false); // salt
+    expect(a.subarray(32, 48).equals(b.subarray(32, 48))).toBe(false); // iv
+  });
+
+  test("many encryptions of the same value are all distinct", () => {
+    const outputs = new Set<string>();
+    for (let i = 0; i < 25; i++) outputs.add(encrypt("same-value"));
+    expect(outputs.size).toBe(25);
+    for (const value of outputs) expect(decrypt(value)).toBe("same-value");
+  });
+});
+
+describe("tamper detection (GCM auth tag)", () => {
+  const flipByte = (ciphertext: string, index: number): string => {
+    const raw = Buffer.from(ciphertext, "base64");
+    raw[index] = raw[index]! ^ 0xff;
+    return raw.toString("base64");
+  };
+
+  test("a flipped ciphertext byte fails authentication instead of returning garbage", () => {
+    const ciphertext = encrypt("sensitive-withings-refresh-token");
+    const tampered = flipByte(ciphertext, HEADER_BYTES + 2);
+
+    expect(() => decrypt(tampered)).toThrow();
+    expect(tampered).not.toBe(ciphertext);
+  });
+
+  test.each([
+    ["salt", 0],
+    ["iv", 32],
+    ["auth tag", 48],
+    ["ciphertext body", HEADER_BYTES],
+  ])("a flipped byte in the %s is rejected", (_region, index) => {
+    const ciphertext = encrypt("0123456789abcdef");
+    expect(() => decrypt(flipByte(ciphertext, index))).toThrow();
+  });
+
+  test("truncating the ciphertext body is rejected", () => {
+    const raw = Buffer.from(encrypt("0123456789abcdef"), "base64");
+    const truncated = raw.subarray(0, raw.length - 4).toString("base64");
+    expect(() => decrypt(truncated)).toThrow();
+  });
+
+  test("appending extra bytes is rejected", () => {
+    const raw = Buffer.from(encrypt("0123456789abcdef"), "base64");
+    const extended = Buffer.concat([raw, Buffer.from([0, 1, 2, 3])]).toString("base64");
+    expect(() => decrypt(extended)).toThrow();
+  });
+
+  test("splicing the header of one ciphertext onto the body of another is rejected", () => {
+    const a = Buffer.from(encrypt("alpha-value"), "base64");
+    const b = Buffer.from(encrypt("beta-value!"), "base64");
+    const spliced = Buffer.concat([
+      a.subarray(0, HEADER_BYTES),
+      b.subarray(HEADER_BYTES),
+    ]).toString("base64");
+
+    expect(() => decrypt(spliced)).toThrow();
+  });
+
+  test("a ciphertext produced under a different secret is rejected", () => {
+    const ciphertext = encrypt("cross-secret");
+    const original = process.env.ENCRYPTION_SECRET;
+    try {
+      process.env.ENCRYPTION_SECRET = "ffffffffffffffffffffffffffffffffffffffff";
+      expect(() => decrypt(ciphertext)).toThrow();
+    } finally {
+      process.env.ENCRYPTION_SECRET = original;
+    }
+    // ...and still decrypts once the correct secret is restored.
+    expect(decrypt(ciphertext)).toBe("cross-secret");
+  });
+});
+
+describe("malformed input", () => {
+  test.each([
+    ["empty string", ""],
+    ["not base64 at all", "not base64 !!!"],
+    ["punctuation only", "$$$$"],
+    ["short valid base64", "aGVsbG8="],
+    ["exactly the header length", Buffer.alloc(HEADER_BYTES).toString("base64")],
+    ["one byte short of the header", Buffer.alloc(HEADER_BYTES - 1).toString("base64")],
+  ])("decrypt throws on %s", (_label, input) => {
+    expect(() => decrypt(input)).toThrow();
+  });
+
+  test("decrypt never silently returns a partial plaintext for junk input", () => {
+    let returned: string | undefined;
+    try {
+      returned = decrypt("Zm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFy");
+    } catch {
+      returned = undefined;
+    }
+    expect(returned).toBeUndefined();
+  });
+});
+
+describe("secret validation", () => {
+  const withSecret = (value: string | undefined, fn: () => void) => {
+    const original = process.env.ENCRYPTION_SECRET;
+    try {
+      if (value === undefined) delete process.env.ENCRYPTION_SECRET;
+      else process.env.ENCRYPTION_SECRET = value;
+      fn();
+    } finally {
+      process.env.ENCRYPTION_SECRET = original;
+    }
+  };
+
+  test("encrypt and decrypt throw when ENCRYPTION_SECRET is missing", () => {
+    const ciphertext = encrypt("value");
+    withSecret(undefined, () => {
+      expect(() => encrypt("value")).toThrow(/ENCRYPTION_SECRET.*required/);
+      expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_SECRET.*required/);
+    });
+  });
+
+  test("a secret shorter than 32 characters is rejected", () => {
+    withSecret("tooshort", () => {
+      expect(() => encrypt("value")).toThrow(
+        "ENCRYPTION_SECRET must be at least 32 characters long"
+      );
+    });
+  });
+
+  test("exactly 32 characters is accepted", () => {
+    withSecret("a".repeat(32), () => {
+      expect(decrypt(encrypt("boundary"))).toBe("boundary");
+    });
+  });
+
+  test("the original secret is restored for the rest of the suite", () => {
+    expect(process.env.ENCRYPTION_SECRET).toBe(TEST_SECRET);
+    expect(decrypt(encrypt("still working"))).toBe("still working");
+  });
+});

--- a/tests/encryption.test.ts
+++ b/tests/encryption.test.ts
@@ -35,7 +35,7 @@ describe("encrypt / decrypt round trip", () => {
     const long = "withings-".repeat(20000); // ~180 KB
     const ciphertext = encrypt(long);
     expect(decrypt(ciphertext)).toBe(long);
-    expect(decrypt(ciphertext).length).toBe(long.length);
+    expect(decrypt(ciphertext)).toHaveLength(long.length);
   });
 
   test("ciphertext is base64 and is not the plaintext", () => {
@@ -50,8 +50,8 @@ describe("encrypt / decrypt round trip", () => {
 
   test("output carries the 64-byte salt+iv+tag header ahead of the ciphertext", () => {
     const raw = Buffer.from(encrypt("abc"), "base64");
-    expect(raw.length).toBe(HEADER_BYTES + 3); // GCM is a stream mode: no padding
-    expect(Buffer.from(encrypt(""), "base64").length).toBe(HEADER_BYTES);
+    expect(raw).toHaveLength(HEADER_BYTES + 3); // GCM is a stream mode: no padding
+    expect(Buffer.from(encrypt(""), "base64")).toHaveLength(HEADER_BYTES);
   });
 });
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,107 @@
+/**
+ * Postgres harness for tests that exercise real SQL (migrations, plpgsql).
+ *
+ * Uses Bun's built-in SQL client, so no new dependency. Each caller gets its
+ * own throwaway schema with the real migrations applied, so tests exercise the
+ * migrations themselves rather than a hand-copied approximation — the class of
+ * bug that motivated this suite only reproduced against a real Postgres.
+ *
+ * Set TEST_DATABASE_URL to run these. Without it they skip rather than fail, so
+ * `bun test` still works on a machine with no database.
+ *
+ *   TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres bun test
+ */
+import { SQL } from "bun";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+export const hasDatabase = Boolean(TEST_DATABASE_URL);
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "..", "supabase", "migrations");
+
+// Needs the pg_cron extension, which a vanilla Postgres does not have. Nothing
+// in it affects application behaviour — it only schedules cleanup jobs.
+const REQUIRES_UNAVAILABLE_EXTENSIONS = new Set(["005_pg_cron_cleanup.sql"]);
+
+// Later migrations also tail a `SELECT cron.schedule(...)` onto an otherwise
+// portable file. Strip those rather than skipping the whole file, so the table
+// definitions around them still get exercised. Matches through to a line that
+// begins with `);`, which is safe against the `$$ ... $$` bodies inside.
+const CRON_SCHEDULE_STATEMENT = /SELECT\s+cron\.schedule\s*\([\s\S]*?\n\);/gi;
+
+// Supabase provisions these roles; a stock Postgres does not, and several
+// migrations grant policies TO them.
+const SUPABASE_ROLES = ["service_role", "authenticated", "anon"];
+
+export interface TestDb {
+  sql: SQL;
+  schema: string;
+  drop: () => Promise<void>;
+}
+
+/**
+ * Create an isolated schema, apply the real migrations into it, and return a
+ * connection scoped to it. `max: 1` keeps a single connection so `search_path`
+ * survives across queries.
+ */
+export async function createTestSchema(label: string): Promise<TestDb> {
+  if (!TEST_DATABASE_URL) {
+    throw new Error("createTestSchema() requires TEST_DATABASE_URL");
+  }
+
+  const schema = `test_${label.replace(/[^a-z0-9]/gi, "_").toLowerCase()}_${Date.now().toString(36)}`;
+  const sql = new SQL(TEST_DATABASE_URL, { max: 1 });
+
+  // Roles referenced by the RLS policies. Idempotent so parallel test files
+  // creating schemas against the same server do not race each other.
+  for (const role of SUPABASE_ROLES) {
+    await sql.unsafe(
+      `DO $harness$ BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
+           CREATE ROLE ${role};
+         END IF;
+       EXCEPTION WHEN duplicate_object THEN NULL;
+       END $harness$;`
+    );
+  }
+
+  await sql.unsafe(`CREATE SCHEMA "${schema}"`);
+  await sql.unsafe(`SET search_path TO "${schema}", public`);
+
+  const files = (await readdir(MIGRATIONS_DIR))
+    .filter((f) => f.endsWith(".sql"))
+    .filter((f) => !REQUIRES_UNAVAILABLE_EXTENSIONS.has(f))
+    .sort();
+
+  for (const file of files) {
+    const raw = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+    const body = raw.replace(CRON_SCHEDULE_STATEMENT, "");
+    try {
+      await sql.unsafe(body);
+    } catch (err) {
+      throw new Error(
+        `migration ${file} failed against the test schema: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  return {
+    sql,
+    schema,
+    drop: async () => {
+      await sql.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await sql.end();
+    },
+  };
+}
+
+/**
+ * Freeze-free clock helper: most rate-limit assertions care about a moment
+ * relative to a fixed origin rather than wall time.
+ */
+export function at(baseIso: string, offsetSeconds: number): string {
+  return new Date(new Date(baseIso).getTime() + offsetSeconds * 1000).toISOString();
+}

--- a/tests/helpers/fake-supabase.ts
+++ b/tests/helpers/fake-supabase.ts
@@ -48,19 +48,32 @@ const NOT_HANDLED: Result = {
 export function makeFakeSupabase(handlers: Record<string, Handler>) {
   const calls: Operation[] = [];
 
-  function builder(op: Operation) {
-    // The chain is thenable: awaiting at any point resolves the handler.
-    const resolve = (): Result => {
+  type Chain = Promise<Result> & {
+    select(columns?: string): Chain;
+    eq(column: string, value: unknown): Chain;
+    gt(column: string, value: unknown): Chain;
+    single(): Chain;
+  };
+
+  function builder(op: Operation): Chain {
+    const run = (): Result => {
       calls.push({ ...op, filters: [...op.filters] });
       const handler = handlers[op.table];
       return handler ? handler(op) : NOT_HANDLED;
     };
 
-    const chain = {
+    // A real Promise rather than a hand-rolled thenable. Resolution is deferred
+    // to a microtask so the entire synchronous chain (.eq().gt().single()) is
+    // built before the handler inspects the operation — which mirrors
+    // supabase-js, where nothing is issued until the builder is awaited.
+    const settled = new Promise<Result>((resolve) => {
+      queueMicrotask(() => resolve(run()));
+    });
+
+    const chain = Object.assign(settled, {
       select(_columns?: string) {
         // .select() after a mutation means "return the affected rows"
-        if (op.action === "select") return chain;
-        op.returning = true;
+        if (op.action !== "select") op.returning = true;
         return chain;
       },
       eq(column: string, value: unknown) {
@@ -75,14 +88,7 @@ export function makeFakeSupabase(handlers: Record<string, Handler>) {
         op.single = true;
         return chain;
       },
-      then(onFulfilled: (r: Result) => unknown, onRejected?: (e: unknown) => unknown) {
-        try {
-          return Promise.resolve(resolve()).then(onFulfilled, onRejected);
-        } catch (err) {
-          return Promise.reject(err).then(onFulfilled, onRejected);
-        }
-      },
-    };
+    }) as Chain;
 
     return chain;
   }

--- a/tests/helpers/fake-supabase.ts
+++ b/tests/helpers/fake-supabase.ts
@@ -1,0 +1,136 @@
+/**
+ * Minimal in-memory stand-in for the supabase-js query builder, so store logic
+ * can be tested without a database.
+ *
+ * Only the surface this codebase actually uses is implemented:
+ *   .from(t).select(c).eq(c,v).gt(c,v).single()
+ *   .from(t).insert(p) / .upsert(p, { onConflict }) / .update(p).eq(...) / .delete().eq(...)
+ *   .update(p).eq(...).select(c)          <- rotateToken's race detection
+ *   .rpc(fn, params).single()
+ *
+ * Wire it in with Bun's module mocking:
+ *
+ *   import { mock } from "bun:test";
+ *   const fake = makeFakeSupabase({ mcp_tokens: (op) => ({ data: ..., error: null }) });
+ *   mock.module("../src/db/supabase.js", () => ({ getSupabaseClient: () => fake.client }));
+ */
+
+export interface Filter {
+  column: string;
+  op: "eq" | "gt";
+  value: unknown;
+}
+
+export interface Operation {
+  table: string;
+  action: "select" | "insert" | "upsert" | "update" | "delete" | "rpc";
+  filters: Filter[];
+  payload?: unknown;
+  onConflict?: string;
+  /** true when .select() was chained AFTER a mutation (return=representation) */
+  returning: boolean;
+  /** true when .single() terminated the chain */
+  single: boolean;
+}
+
+export interface Result {
+  data: unknown;
+  error: { message: string; code?: string } | null;
+}
+
+export type Handler = (op: Operation) => Result;
+
+const NOT_HANDLED: Result = {
+  data: null,
+  error: { message: "no handler registered for this operation", code: "TEST" },
+};
+
+export function makeFakeSupabase(handlers: Record<string, Handler>) {
+  const calls: Operation[] = [];
+
+  function builder(op: Operation) {
+    // The chain is thenable: awaiting at any point resolves the handler.
+    const resolve = (): Result => {
+      calls.push({ ...op, filters: [...op.filters] });
+      const handler = handlers[op.table];
+      return handler ? handler(op) : NOT_HANDLED;
+    };
+
+    const chain = {
+      select(_columns?: string) {
+        // .select() after a mutation means "return the affected rows"
+        if (op.action === "select") return chain;
+        op.returning = true;
+        return chain;
+      },
+      eq(column: string, value: unknown) {
+        op.filters.push({ column, op: "eq", value });
+        return chain;
+      },
+      gt(column: string, value: unknown) {
+        op.filters.push({ column, op: "gt", value });
+        return chain;
+      },
+      single() {
+        op.single = true;
+        return chain;
+      },
+      then(onFulfilled: (r: Result) => unknown, onRejected?: (e: unknown) => unknown) {
+        try {
+          return Promise.resolve(resolve()).then(onFulfilled, onRejected);
+        } catch (err) {
+          return Promise.reject(err).then(onFulfilled, onRejected);
+        }
+      },
+    };
+
+    return chain;
+  }
+
+  const client = {
+    from(table: string) {
+      const base = (action: Operation["action"], payload?: unknown, onConflict?: string) =>
+        builder({ table, action, filters: [], payload, onConflict, returning: false, single: false });
+
+      return {
+        select: (columns?: string) => base("select").select(columns),
+        insert: (payload: unknown) => base("insert", payload),
+        upsert: (payload: unknown, opts?: { onConflict?: string }) =>
+          base("upsert", payload, opts?.onConflict),
+        update: (payload: unknown) => base("update", payload),
+        delete: () => base("delete"),
+      };
+    },
+    rpc(fn: string, params?: unknown) {
+      return builder({
+        table: fn,
+        action: "rpc",
+        filters: [],
+        payload: params,
+        returning: false,
+        single: false,
+      });
+    },
+  };
+
+  return {
+    client,
+    calls,
+    /** operations recorded against a given table/function, in order */
+    callsFor(table: string) {
+      return calls.filter((c) => c.table === table);
+    },
+    reset() {
+      calls.length = 0;
+    },
+  };
+}
+
+/** Convenience: a handler that always returns rows. */
+export const rows = (data: unknown): Handler => () => ({ data, error: null });
+
+/** Convenience: a handler that always returns "no rows" the way PostgREST does. */
+export const noRows: Handler = () => ({
+  data: null,
+  error: { message: "no rows returned", code: "PGRST116" },
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Unit tests for src/utils/logger.ts
+ *
+ * Redaction here is security-relevant: this repository is public and its logs
+ * must never carry credentials. These tests pin the redaction behaviour, and
+ * also document one real limitation of it (see "KNOWN GAP" below).
+ */
+import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import {
+  logger,
+  createLogger,
+  calculateDateRangeDays,
+  categorizeError,
+} from "../src/utils/logger.js";
+
+type Spy = ReturnType<typeof spyOn>;
+
+let logSpy: Spy;
+let warnSpy: Spy;
+let errorSpy: Spy;
+let originalLogLevel: string | undefined;
+
+beforeEach(() => {
+  originalLogLevel = process.env.LOG_LEVEL;
+  logSpy = spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+  if (originalLogLevel === undefined) delete process.env.LOG_LEVEL;
+  else process.env.LOG_LEVEL = originalLogLevel;
+});
+
+/** The logger reads LOG_LEVEL in its constructor, so build it after setting env. */
+function loggerAtLevel(level: string, context: Record<string, unknown> = {}) {
+  process.env.LOG_LEVEL = level;
+  return logger.child(context);
+}
+
+/** Last string handed to console.log. */
+function lastLog(): string {
+  const calls = logSpy.mock.calls;
+  return String(calls[calls.length - 1]?.[0]);
+}
+
+/** The JSON blob appended after the message, parsed back into an object. */
+function lastLoggedData(): Record<string, unknown> {
+  const output = lastLog();
+  const jsonStart = output.indexOf("{");
+  return JSON.parse(output.slice(jsonStart));
+}
+
+// The full redaction list as it exists in src/utils/logger.ts today.
+const REDACTED_KEYS = [
+  "token",
+  "access_token",
+  "refresh_token",
+  "accessToken",
+  "refreshToken",
+  "bearer",
+  "authorization",
+  "Authorization",
+  "code",
+  "auth_code",
+  "authCode",
+  "client_secret",
+  "clientSecret",
+  "code_verifier",
+  "codeVerifier",
+  "code_challenge",
+  "codeChallenge",
+  "userid",
+  "userId",
+  "user_id",
+  "email",
+  "password",
+  "sessionId",
+  "session_id",
+  "state",
+  "apiKey",
+  "api_key",
+  "secret",
+];
+
+describe("redaction of sensitive keys", () => {
+  test.each(REDACTED_KEYS)("redacts %s", (key) => {
+    const log = loggerAtLevel("trace");
+    log.info("event", { [key]: "SUPER-SECRET-VALUE" });
+
+    const data = lastLoggedData();
+    expect(data[key]).toBe("[REDACTED]");
+    expect(lastLog()).not.toContain("SUPER-SECRET-VALUE");
+  });
+
+  test("redacts every sensitive key in one payload", () => {
+    const log = loggerAtLevel("trace");
+    const payload: Record<string, unknown> = {};
+    for (const key of REDACTED_KEYS) payload[key] = "SUPER-SECRET-VALUE";
+    log.info("event", payload);
+
+    const data = lastLoggedData();
+    for (const key of REDACTED_KEYS) expect(data[key]).toBe("[REDACTED]");
+    expect(lastLog()).not.toContain("SUPER-SECRET-VALUE");
+  });
+
+  test("redacts the specific keys named in the privacy policy", () => {
+    const log = loggerAtLevel("trace");
+    log.info("oauth", {
+      token: "t",
+      access_token: "at",
+      code: "c",
+      client_secret: "cs",
+      code_verifier: "cv",
+      userid: 12345,
+      email: "user@example.com",
+      password: "hunter2",
+      sessionId: "sess-1",
+      state: "st",
+    });
+
+    const output = lastLog();
+    for (const value of [
+      "hunter2",
+      "user@example.com",
+      "12345",
+      "sess-1",
+      "cs",
+      "cv",
+    ]) {
+      expect(output).not.toContain(value);
+    }
+    expect(lastLoggedData()).toEqual({
+      token: "[REDACTED]",
+      access_token: "[REDACTED]",
+      code: "[REDACTED]",
+      client_secret: "[REDACTED]",
+      code_verifier: "[REDACTED]",
+      userid: "[REDACTED]",
+      email: "[REDACTED]",
+      password: "[REDACTED]",
+      sessionId: "[REDACTED]",
+      state: "[REDACTED]",
+    });
+  });
+
+  test("redacts non-string values too (numbers, objects, arrays)", () => {
+    const log = loggerAtLevel("trace");
+    log.info("event", {
+      userid: 987654,
+      token: { value: "nested-secret" },
+      state: ["a", "b"],
+    });
+
+    expect(lastLoggedData()).toEqual({
+      userid: "[REDACTED]",
+      token: "[REDACTED]",
+      state: "[REDACTED]",
+    });
+    expect(lastLog()).not.toContain("nested-secret");
+  });
+
+  test("reaches nested objects at any depth", () => {
+    const log = loggerAtLevel("trace");
+    log.info("nested", {
+      request: {
+        headers: { authorization: "Bearer abc123" },
+        body: { deep: { deeper: { client_secret: "shhh", keep: "visible" } } },
+      },
+    });
+
+    const output = lastLog();
+    expect(output).not.toContain("Bearer abc123");
+    expect(output).not.toContain("shhh");
+    expect(lastLoggedData()).toEqual({
+      request: {
+        headers: { authorization: "[REDACTED]" },
+        body: { deep: { deeper: { client_secret: "[REDACTED]", keep: "visible" } } },
+      },
+    });
+  });
+
+  test("reaches objects inside arrays", () => {
+    const log = loggerAtLevel("trace");
+    log.info("batch", {
+      sessions: [
+        { sessionId: "s1", tool: "get_sleep" },
+        { sessionId: "s2", tool: "get_measures" },
+      ],
+    });
+
+    expect(lastLoggedData()).toEqual({
+      sessions: [
+        { sessionId: "[REDACTED]", tool: "get_sleep" },
+        { sessionId: "[REDACTED]", tool: "get_measures" },
+      ],
+    });
+  });
+
+  test("non-sensitive keys pass through untouched", () => {
+    const log = loggerAtLevel("trace");
+    log.info("tool call", {
+      component: "tools:sleep",
+      tool: "get_sleep_summary",
+      durationMs: 143,
+      ok: true,
+      rangeDays: 7,
+      nothing: null,
+      nested: { status: 0, more: false },
+    });
+
+    expect(lastLoggedData()).toEqual({
+      component: "tools:sleep",
+      tool: "get_sleep_summary",
+      durationMs: 143,
+      ok: true,
+      rangeDays: 7,
+      nothing: null,
+      nested: { status: 0, more: false },
+    });
+  });
+
+  test("matching is exact and case-sensitive — near-miss keys are NOT redacted", () => {
+    const log = loggerAtLevel("trace");
+    log.info("near misses", {
+      tokenCount: 42,
+      my_token: "visible",
+      TOKEN: "visible",
+      Email: "visible",
+      user: "visible",
+    });
+
+    const data = lastLoggedData();
+    expect(data.tokenCount).toBe(42);
+    expect(data.my_token).toBe("visible");
+    expect(data.TOKEN).toBe("visible");
+    expect(data.Email).toBe("visible");
+    expect(data.user).toBe("visible");
+  });
+
+  // KNOWN GAP: redaction walks object KEYS only. A secret interpolated into the
+  // message string, or one that appears as an array/scalar VALUE rather than
+  // under a sensitive key, is logged verbatim. This test records the current
+  // behaviour so a future change to it is a deliberate, visible decision — it
+  // is not an endorsement. Callers must keep secrets out of message strings.
+  test("KNOWN GAP: secrets embedded in the message string are NOT redacted", () => {
+    const log = loggerAtLevel("trace");
+    log.info("Exchanging code abc123secret for a token");
+
+    expect(lastLog()).toContain("abc123secret");
+  });
+
+  test("KNOWN GAP: secrets appearing as values under a safe key are NOT redacted", () => {
+    const log = loggerAtLevel("trace");
+    log.info("event", { details: "client_secret=abc123secret", values: ["abc123secret"] });
+
+    expect(lastLog()).toContain("abc123secret");
+    expect(lastLoggedData()).toEqual({
+      details: "client_secret=abc123secret",
+      values: ["abc123secret"],
+    });
+  });
+});
+
+describe("log level filtering", () => {
+  const emitAll = (level: string) => {
+    const log = loggerAtLevel(level, { component: "test" });
+    log.trace("t");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+  };
+
+  test("LOG_LEVEL=info suppresses trace and debug", () => {
+    emitAll("info");
+
+    const messages = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(messages).toEqual(["INFO  [test] i"]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("LOG_LEVEL=trace emits everything", () => {
+    emitAll("trace");
+
+    expect(logSpy).toHaveBeenCalledTimes(3); // trace + debug + info
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("LOG_LEVEL=debug emits debug and above but not trace", () => {
+    emitAll("debug");
+
+    expect(logSpy).toHaveBeenCalledTimes(2); // debug + info
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("LOG_LEVEL=warn suppresses everything below warn", () => {
+    emitAll("warn");
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("LOG_LEVEL=error only emits errors", () => {
+    emitAll("error");
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+    expect(warnSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("LOG_LEVEL is case-insensitive", () => {
+    emitAll("ERROR");
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+    expect(warnSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unrecognised LOG_LEVEL falls back to info", () => {
+    emitAll("gibberish");
+
+    expect(logSpy).toHaveBeenCalledTimes(1); // info only
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unset LOG_LEVEL defaults to info", () => {
+    delete process.env.LOG_LEVEL;
+    const log = logger.child({ component: "test" });
+    log.debug("d");
+    log.info("i");
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("output format and routing", () => {
+  test("routes error to console.error, warn to console.warn, rest to console.log", () => {
+    const log = loggerAtLevel("trace", { component: "oauth" });
+
+    log.error("boom");
+    expect(String(errorSpy.mock.calls[0]?.[0])).toBe("ERROR [oauth] boom");
+
+    log.warn("careful");
+    expect(String(warnSpy.mock.calls[0]?.[0])).toBe("WARN  [oauth] careful");
+
+    log.info("hello");
+    expect(lastLog()).toBe("INFO  [oauth] hello");
+
+    log.debug("details");
+    expect(lastLog()).toBe("DEBUG [oauth] details");
+
+    log.trace("very detailed");
+    expect(lastLog()).toBe("TRACE [oauth] very detailed");
+  });
+
+  test("omits the component prefix when there is no component in context", () => {
+    const log = loggerAtLevel("trace");
+    log.info("plain message");
+
+    expect(lastLog()).toBe("INFO  plain message");
+  });
+
+  test("appends the redacted payload as JSON after the message", () => {
+    const log = loggerAtLevel("trace", { component: "oauth" });
+    log.info("Starting OAuth authorization flow", { clientKnown: true, token: "x" });
+
+    expect(lastLog()).toBe(
+      'INFO  [oauth] Starting OAuth authorization flow {"clientKnown":true,"token":"[REDACTED]"}'
+    );
+  });
+
+  test("falsy data payloads are omitted entirely", () => {
+    const log = loggerAtLevel("trace");
+
+    log.info("no data");
+    expect(lastLog()).toBe("INFO  no data");
+
+    log.info("zero", 0);
+    expect(lastLog()).toBe("INFO  zero");
+
+    log.info("empty string", "");
+    expect(lastLog()).toBe("INFO  empty string");
+
+    log.info("null", null);
+    expect(lastLog()).toBe("INFO  null");
+
+    // ...but an empty object is truthy and is serialised.
+    log.info("empty object", {});
+    expect(lastLog()).toBe("INFO  empty object {}");
+  });
+
+  test("primitive (non-object) data is serialised without redaction", () => {
+    const log = loggerAtLevel("trace");
+    log.info("count", 42);
+    expect(lastLog()).toBe("INFO  count 42");
+  });
+});
+
+describe("createLogger and child contexts", () => {
+  test("createLogger attaches the component to the output", () => {
+    process.env.LOG_LEVEL = "trace";
+    const log = createLogger({ component: "tools:sleep" });
+    log.info("get_sleep invoked");
+
+    expect(lastLog()).toBe("INFO  [tools:sleep] get_sleep invoked");
+  });
+
+  test("child merges context, with the child's value winning", () => {
+    process.env.LOG_LEVEL = "trace";
+    const parent = createLogger({ component: "oauth" });
+    const child = parent.child({ component: "oauth:callback" });
+
+    child.info("callback received");
+    expect(lastLog()).toBe("INFO  [oauth:callback] callback received");
+
+    parent.info("still oauth");
+    expect(lastLog()).toBe("INFO  [oauth] still oauth");
+  });
+
+  test("child loggers redact exactly like their parent", () => {
+    process.env.LOG_LEVEL = "trace";
+    createLogger({ component: "middleware" }).info("auth", {
+      authorization: "Bearer leak",
+    });
+
+    expect(lastLog()).not.toContain("Bearer leak");
+    expect(lastLoggedData()).toEqual({ authorization: "[REDACTED]" });
+  });
+});
+
+describe("calculateDateRangeDays", () => {
+  test("returns the day span between two valid dates", () => {
+    expect(calculateDateRangeDays("2024-01-01", "2024-01-31")).toBe(30);
+    expect(calculateDateRangeDays("2024-01-15", "2024-01-15")).toBe(0);
+    expect(calculateDateRangeDays("2024-02-28", "2024-03-01")).toBe(2); // leap year
+  });
+
+  test("returns undefined for missing, malformed or reversed ranges", () => {
+    expect(calculateDateRangeDays(undefined, "2024-01-31")).toBeUndefined();
+    expect(calculateDateRangeDays("2024-01-01", undefined)).toBeUndefined();
+    expect(calculateDateRangeDays("01/01/2024", "2024-01-31")).toBeUndefined();
+    expect(calculateDateRangeDays("2024-13-45", "2024-01-31")).toBeUndefined();
+    expect(calculateDateRangeDays("2024-01-31", "2024-01-01")).toBeUndefined();
+  });
+});
+
+describe("categorizeError", () => {
+  test.each([
+    ["Withings access token expired", "auth_expired"],
+    ["Request failed with 401", "auth_expired"],
+    ["Rate limit exceeded", "rate_limited"],
+    ["429 Too Many Requests", "rate_limited"],
+    ["Invalid date format: foo. Expected YYYY-MM-DD format.", "invalid_date_format"],
+    ["signalid is required", "missing_required_param"],
+    ["Withings API returned an error", "withings_api_error"],
+    ["network unreachable", "network_error"],
+    ["something else entirely", "unknown"],
+  ])("categorises %j as %s", (message, expected) => {
+    expect(categorizeError(new Error(message))).toBe(expected);
+  });
+
+  // The checks run in a fixed order, so an earlier pattern wins even when a
+  // later one looks like a better fit. Documented rather than judged.
+  test("earlier patterns win: 'startdate is required' is a date error, not a param error", () => {
+    expect(categorizeError(new Error("startdate is required"))).toBe(
+      "invalid_date_format"
+    );
+  });
+
+  test("non-Error values are unknown", () => {
+    expect(categorizeError("a string")).toBe("unknown");
+    expect(categorizeError(null)).toBe("unknown");
+    expect(categorizeError(undefined)).toBe("unknown");
+  });
+});

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the SQL migrations in supabase/migrations.
+ *
+ * These migrations are applied by hand against a hosted Supabase project, so
+ * nothing else in CI would ever notice a migration that no longer applies —
+ * a typo, a column referenced before it is added, or two files that apply fine
+ * individually but not in sequence. `createTestSchema()` applies every file in
+ * filename order into a throwaway schema, so "it did not throw" is the
+ * assertion that matters here.
+ *
+ * The structural assertions that follow pin the shape the application code
+ * actually depends on: the tables the stores read/write, and specifically the
+ * columns added by later migrations (006/007/008), which are the ones a missed
+ * or out-of-order migration would silently drop.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { createTestSchema, hasDatabase, type TestDb } from "./helpers/db.ts";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "supabase", "migrations");
+
+/** Every table the application code touches, and the migration that creates it. */
+const EXPECTED_TABLES = [
+  "mcp_tokens", // 001
+  "oauth_sessions", // 001
+  "auth_codes", // 001
+  "registered_clients", // 001
+  "rate_limits", // 001
+  "tool_analytics", // 003
+  "mcp_sessions", // 006
+];
+
+/**
+ * Columns introduced after the initial schema. Each one is load-bearing: if the
+ * migration that adds it is skipped, the corresponding feature fails at runtime
+ * rather than at deploy time.
+ */
+const EXPECTED_ADDED_COLUMNS: Array<[table: string, column: string, why: string]> = [
+  ["mcp_sessions", "session_id", "006: session -> token registry, so a restarted instance rebuilds sessions instead of 404ing"],
+  ["mcp_tokens", "previous_mcp_token", "007: rotation grace window that makes refresh_token retries idempotent"],
+  ["rate_limits", "previous_count", "008: the second counter the sliding window weights"],
+];
+
+describe("migration files", () => {
+  test("filenames sort lexicographically in numeric order", async () => {
+    // createTestSchema() applies files in plain `.sort()` order, so a file
+    // numbered without zero padding (e.g. `10_x.sql`) would apply BEFORE
+    // `002_x.sql` and break the sequence. Guard the naming convention itself;
+    // this needs no database.
+    const files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith(".sql")).sort();
+
+    expect(files.length).toBeGreaterThan(0);
+
+    const prefixes = files.map((f) => {
+      const match = /^(\d+)_/.exec(f);
+      expect(match, `migration ${f} must start with a zero-padded numeric prefix`).not.toBeNull();
+      return { file: f, width: match![1].length, value: Number(match![1]) };
+    });
+
+    // Uniform prefix width is what makes lexicographic order == numeric order.
+    const widths = new Set(prefixes.map((p) => p.width));
+    expect([...widths]).toHaveLength(1);
+
+    const values = prefixes.map((p) => p.value);
+    expect(values).toEqual([...values].sort((a, b) => a - b));
+    // No duplicate numbers: two files sharing a prefix have undefined ordering.
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe.skipIf(!hasDatabase)("migrations applied to Postgres", () => {
+  let db!: TestDb;
+
+  beforeAll(async () => {
+    db = await createTestSchema("migrations");
+  });
+
+  afterAll(async () => {
+    await db?.drop();
+  });
+
+  test("every migration applies cleanly, in filename order, into a fresh schema", async () => {
+    // The point of this test is that createTestSchema() resolves at all: it
+    // rethrows as `migration <file> failed against the test schema: ...`, which
+    // names the offending file. A second, independent schema is built here so
+    // the assertion is about a genuinely fresh apply rather than the shared one.
+    const fresh = await createTestSchema("migrations_fresh");
+    try {
+      expect(fresh.schema).toMatch(/^test_migrations_fresh_/);
+    } finally {
+      await fresh.drop();
+    }
+  });
+
+  test("creates every table the application depends on", async () => {
+    const rows = await db.sql.unsafe(
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_schema = $1
+          AND table_type = 'BASE TABLE'`,
+      [db.schema]
+    );
+    const actual = new Set(rows.map((r: { table_name: string }) => r.table_name));
+
+    for (const table of EXPECTED_TABLES) {
+      expect(actual.has(table), `expected table ${table} to exist after migrations`).toBe(true);
+    }
+  });
+
+  test("adds the columns introduced by migrations 006, 007 and 008", async () => {
+    const rows = await db.sql.unsafe(
+      `SELECT table_name, column_name
+         FROM information_schema.columns
+        WHERE table_schema = $1`,
+      [db.schema]
+    );
+    const actual = new Set(
+      rows.map((r: { table_name: string; column_name: string }) => `${r.table_name}.${r.column_name}`)
+    );
+
+    for (const [table, column, why] of EXPECTED_ADDED_COLUMNS) {
+      expect(actual.has(`${table}.${column}`), `${table}.${column} missing — ${why}`).toBe(true);
+    }
+  });
+
+  test("rate_limits.previous_count is NOT NULL with a 0 default", async () => {
+    // 008 adds this column to a table that already has rows in production. If
+    // it were nullable, `previous_count * weight` would evaluate to NULL for
+    // pre-existing rows and the estimate comparison would silently fall through
+    // to "allowed", disabling rate limiting for every existing identifier.
+    const rows = await db.sql.unsafe(
+      `SELECT is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'rate_limits' AND column_name = 'previous_count'`,
+      [db.schema]
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_nullable).toBe("NO");
+    expect(String(rows[0].column_default)).toContain("0");
+  });
+
+  test("leaves exactly one check_rate_limit function, with the signature the app calls", async () => {
+    // 004, 008 and 009 all CREATE OR REPLACE this function. Replacement only
+    // happens when the argument list matches exactly — change an argument type
+    // in a later migration and Postgres creates an OVERLOAD instead, leaving
+    // the old buggy definition live and making the PostgREST rpc() call
+    // ambiguous. src/server/rate-limiter.ts calls it as
+    // (p_identifier, p_max_requests, p_window_ms).
+    const rows = await db.sql.unsafe(
+      `SELECT pg_get_function_identity_arguments(p.oid) AS args
+         FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = $1 AND p.proname = 'check_rate_limit'`,
+      [db.schema]
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].args)).toBe("character varying, integer, bigint");
+  });
+
+  test("the live check_rate_limit is the clamped version from 009", async () => {
+    // 009 is the last migration to replace the function; if it were skipped or
+    // applied out of order, the stale-boundary clamp would be absent and the
+    // ~43-minute Retry-After bug would be back. Assert on the clamp itself
+    // rather than a comment, so a reworded header does not fail the test.
+    const rows = await db.sql.unsafe(
+      `SELECT prosrc
+         FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = $1 AND p.proname = 'check_rate_limit'`,
+      [db.schema]
+    );
+
+    const source = String(rows[0].prosrc).replace(/\s+/g, " ");
+    expect(source).toContain("IF v_reset_time > v_now + v_window THEN");
+    expect(source).toContain("v_reset_time := v_now + v_window;");
+  });
+});

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -146,8 +146,14 @@ describe.skipIf(!hasDatabase)("migrations applied to Postgres", () => {
     // happens when the argument list matches exactly — change an argument type
     // in a later migration and Postgres creates an OVERLOAD instead, leaving
     // the old buggy definition live and making the PostgREST rpc() call
-    // ambiguous. src/server/rate-limiter.ts calls it as
-    // (p_identifier, p_max_requests, p_window_ms).
+    // ambiguous.
+    //
+    // The parameter NAMES are load-bearing, not just the types:
+    // src/server/rate-limiter.ts calls
+    //   supabase.rpc("check_rate_limit", { p_identifier, p_max_requests, p_window_ms })
+    // and PostgREST binds those by name. Renaming a parameter in a migration
+    // would leave the SQL valid but break every call at runtime, so assert the
+    // full identity — which is what pg_get_function_identity_arguments returns.
     const rows = await db.sql.unsafe(
       `SELECT pg_get_function_identity_arguments(p.oid) AS args
          FROM pg_proc p
@@ -157,7 +163,9 @@ describe.skipIf(!hasDatabase)("migrations applied to Postgres", () => {
     );
 
     expect(rows).toHaveLength(1);
-    expect(String(rows[0].args)).toBe("character varying, integer, bigint");
+    expect(String(rows[0].args)).toBe(
+      "p_identifier character varying, p_max_requests integer, p_window_ms bigint"
+    );
   });
 
   test("the live check_rate_limit is the clamped version from 009", async () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the `check_rate_limit` plpgsql function (migrations 004 -> 008 -> 009).
+ *
+ * `check_rate_limit` is a weighted two-window sliding counter:
+ *
+ *   estimate = previous_count * (time_left_in_window / window) + current_count
+ *
+ * Two real bugs shipped from this function, and most of what is below exists to
+ * stop them coming back:
+ *
+ *   1. `interval * numeric` has no operator in Postgres (only
+ *      `interval * double precision`). The retry-time arithmetic on the DENIED
+ *      path hit it, so *every* denied request raised instead of returning 429.
+ *      The allowed path never touches that code, so a happy-path-only test
+ *      suite would have shipped it again.
+ *   2. A row written under a LONGER window kept its distant `reset_time`, which
+ *      pinned the decay weight at 1.0 forever: the window never rolled and
+ *      Retry-After came back as ~43 minutes instead of ~8. Migration 009 clamps
+ *      the stored boundary back into range.
+ *
+ * TECHNIQUE: the deployed function takes no clock parameter — it reads `NOW()`.
+ * Rather than sleep (which would make a 5-minute-window suite untestable), every
+ * test SEEDS the `rate_limits` row directly with a chosen
+ * `(request_count, previous_count, reset_time)` to place the identifier at an
+ * arbitrary point in its window, then calls `check_rate_limit` exactly once and
+ * asserts on the returned `(allowed, request_count, reset_time)` plus the row
+ * left behind.
+ *
+ * `reset_time` is always expressed relative to `now()` inside SQL. Note that
+ * `now()` is transaction_timestamp(), so the `now()` in the outer SELECT is the
+ * *same instant* as the `NOW()` the function reads — the returned offsets are
+ * exact, not jittery. Seeding happens in an earlier transaction, so seeded
+ * offsets drift by a few milliseconds; assertions are toleranced accordingly.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { createTestSchema, hasDatabase, type TestDb } from "./helpers/db.ts";
+
+/** Production config for the OAuth endpoints: 30 requests per 5 minutes. */
+const MAX = 30;
+const WINDOW_MS = 300_000;
+const WINDOW_S = WINDOW_MS / 1000;
+
+interface CheckResult {
+  allowed: boolean;
+  /** Ceiling of the weighted estimate the function computed. */
+  request_count: number;
+  /** Seconds from the call instant until the returned reset_time. */
+  reset_in_seconds: number;
+}
+
+interface StoredRow {
+  request_count: number;
+  previous_count: number;
+  /** Seconds from read time until the persisted reset_time. */
+  reset_in_seconds: number;
+}
+
+describe.skipIf(!hasDatabase)("check_rate_limit", () => {
+  let db!: TestDb;
+
+  beforeAll(async () => {
+    db = await createTestSchema("rate_limit");
+  });
+
+  afterAll(async () => {
+    await db?.drop();
+  });
+
+  /**
+   * Call the function once. `reset_in_seconds` is computed in the same
+   * statement (therefore the same transaction, therefore the same `now()`) so
+   * it is an exact offset from the clock the function itself used.
+   */
+  async function check(
+    identifier: string,
+    maxRequests = MAX,
+    windowMs = WINDOW_MS
+  ): Promise<CheckResult> {
+    const rows = await db.sql.unsafe(
+      `SELECT allowed,
+              request_count,
+              EXTRACT(EPOCH FROM (reset_time - now()))::double precision AS reset_in_seconds
+         FROM check_rate_limit($1::varchar, $2::integer, $3::bigint)`,
+      [identifier, maxRequests, windowMs]
+    );
+    const row = rows[0];
+    return {
+      allowed: Boolean(row.allowed),
+      request_count: Number(row.request_count),
+      reset_in_seconds: Number(row.reset_in_seconds),
+    };
+  }
+
+  /**
+   * Place an identifier at an arbitrary point in its window. `resetOffsetSeconds`
+   * is relative to now: positive = window still open, negative = window elapsed.
+   */
+  async function seed(
+    identifier: string,
+    current: number,
+    previous: number,
+    resetOffsetSeconds: number
+  ): Promise<void> {
+    await db.sql.unsafe(
+      `INSERT INTO rate_limits (identifier, request_count, previous_count, reset_time, updated_at)
+       VALUES ($1, $2, $3, now() + ($4::double precision * interval '1 second'), now())
+       ON CONFLICT (identifier) DO UPDATE
+          SET request_count  = EXCLUDED.request_count,
+              previous_count = EXCLUDED.previous_count,
+              reset_time     = EXCLUDED.reset_time,
+              updated_at     = EXCLUDED.updated_at`,
+      [identifier, current, previous, resetOffsetSeconds]
+    );
+  }
+
+  /** Read back what the function persisted — the roll/clamp is only visible here. */
+  async function readRow(identifier: string): Promise<StoredRow> {
+    const rows = await db.sql.unsafe(
+      `SELECT request_count,
+              previous_count,
+              EXTRACT(EPOCH FROM (reset_time - now()))::double precision AS reset_in_seconds
+         FROM rate_limits
+        WHERE identifier = $1`,
+      [identifier]
+    );
+    const row = rows[0];
+    return {
+      request_count: Number(row.request_count),
+      previous_count: Number(row.previous_count),
+      reset_in_seconds: Number(row.reset_in_seconds),
+    };
+  }
+
+  test("a fresh identifier is allowed and starts a window at count 1", async () => {
+    const id = "fresh:identifier";
+
+    const result = await check(id);
+
+    expect(result.allowed).toBe(true);
+    expect(result.request_count).toBe(1);
+    // A brand new row must open a full window, not inherit anything.
+    expect(result.reset_in_seconds).toBeGreaterThan(WINDOW_S - 5);
+    expect(result.reset_in_seconds).toBeLessThanOrEqual(WINDOW_S + 1);
+
+    const stored = await readRow(id);
+    expect(stored.request_count).toBe(1);
+    expect(stored.previous_count).toBe(0);
+  });
+
+  test("consecutive requests under the limit are allowed and increment the count", async () => {
+    const id = "under:limit";
+
+    // No seeding: three real calls in the same window. previous_count is 0, so
+    // the weighted estimate is just the current count and the reported
+    // request_count must track it exactly (X-RateLimit-Remaining depends on it).
+    expect(await check(id)).toMatchObject({ allowed: true, request_count: 1 });
+    expect(await check(id)).toMatchObject({ allowed: true, request_count: 2 });
+    expect(await check(id)).toMatchObject({ allowed: true, request_count: 3 });
+
+    const stored = await readRow(id);
+    expect(stored.request_count).toBe(3);
+    expect(stored.previous_count).toBe(0);
+  });
+
+  test("a request at the limit is denied", async () => {
+    const id = "at:limit";
+    // Half the window still to run, budget fully spent in the current window.
+    await seed(id, MAX, 0, 150);
+
+    const result = await check(id);
+
+    expect(result.allowed).toBe(false);
+    // estimate = 0 * 0.5 + 30 = 30, and the check is `>= p_max_requests`.
+    expect(result.request_count).toBe(MAX);
+  });
+
+  test("the denied path returns a row instead of raising (bug 1: interval * numeric)", async () => {
+    // REGRESSION TEST for bug 1. Only the denied path multiplies an interval by
+    // a ratio, and `interval * numeric` has no operator in Postgres — the fix
+    // was to cast both operands to DOUBLE PRECISION. If that cast is ever
+    // dropped, these calls raise `operator does not exist: interval * numeric`
+    // and every rate-limited request 500s instead of returning 429.
+    //
+    // There are TWO such expressions (one per denial branch), so both are
+    // exercised here.
+
+    // Branch A: v_current >= p_max_requests
+    //   v_retry_at := (reset + window) - window * (max::float8 / current::float8)
+    const currentBranch = "denied:current-branch";
+    await seed(currentBranch, 45, 0, 120);
+    const a = await check(currentBranch);
+    expect(a).toBeDefined();
+    expect(a.allowed).toBe(false);
+
+    // Branch B: v_current < p_max_requests but v_previous > 0 carries it over
+    //   v_retry_at := reset - window * ((max - current)::float8 / previous::float8)
+    const previousBranch = "denied:previous-branch";
+    await seed(previousBranch, 5, MAX, 299);
+    const b = await check(previousBranch);
+    expect(b).toBeDefined();
+    expect(b.allowed).toBe(false);
+    // estimate = 30 * (299/300) + 5 = 34.9 -> CEIL = 35
+    expect(b.request_count).toBeGreaterThanOrEqual(34);
+    expect(b.request_count).toBeLessThanOrEqual(35);
+  });
+
+  test("a denial returns a Retry-After in the future and within two windows", async () => {
+    // src/server/rate-limiter.ts turns the returned reset_time straight into
+    // Retry-After: `ceil((resetTime - Date.now()) / 1000)`. A past value would
+    // emit a negative/zero Retry-After; a value beyond two windows is by
+    // definition wrong, because a fully-burned window decays completely in at
+    // most two window lengths under this algorithm.
+    const cases: Array<[string, number, number, number]> = [
+      // [identifier, current, previous, resetOffsetSeconds]
+      ["retry:current-at-limit", MAX, 0, 150],
+      ["retry:way-over", 82, 0, 200],
+      ["retry:carried-over", 5, MAX, 299],
+      ["retry:both-full", MAX, MAX, 250],
+    ];
+
+    for (const [id, current, previous, offset] of cases) {
+      await seed(id, current, previous, offset);
+      const result = await check(id);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reset_in_seconds).toBeGreaterThan(0);
+      expect(result.reset_in_seconds).toBeLessThanOrEqual(2 * WINDOW_S + 1);
+    }
+  });
+
+  test("an elapsed window rolls: the current count becomes the previous count", async () => {
+    const id = "roll:one-window";
+    // Window ended 60s ago (less than one window ago), so exactly one window
+    // has elapsed and the burst it contains must still partially count.
+    await seed(id, 12, 7, -60);
+
+    const result = await check(id);
+
+    // After the roll: previous = 12, current = 0, reset = old reset + window,
+    // i.e. now + 240s. weight = 240/300 = 0.8 -> estimate = 12 * 0.8 = 9.6.
+    expect(result.allowed).toBe(true);
+    expect(result.request_count).toBe(11); // CEIL(9.6) + 1 for this request
+    expect(result.reset_in_seconds).toBeGreaterThan(235);
+    expect(result.reset_in_seconds).toBeLessThan(245);
+
+    const stored = await readRow(id);
+    // The roll must be PERSISTED, otherwise every subsequent call recomputes it
+    // from the same stale row and the counters never advance.
+    expect(stored.previous_count).toBe(12); // old current carried over
+    expect(stored.request_count).toBe(1); // current reset, then this request
+  });
+
+  test("an identifier idle for more than one window resets both counts", async () => {
+    const id = "roll:long-idle";
+    // Window ended 400s ago — more than one full window (300s), so nothing from
+    // the old window still falls inside the trailing window.
+    await seed(id, 25, MAX, -400);
+
+    const result = await check(id);
+
+    expect(result.allowed).toBe(true);
+    expect(result.request_count).toBe(1); // estimate 0, plus this request
+
+    const stored = await readRow(id);
+    expect(stored.request_count).toBe(1);
+    expect(stored.previous_count).toBe(0); // nothing carried; no phantom debt
+    // A fully fresh window, not a continuation of the abandoned one.
+    expect(stored.reset_in_seconds).toBeGreaterThan(WINDOW_S - 5);
+    expect(stored.reset_in_seconds).toBeLessThanOrEqual(WINDOW_S + 1);
+  });
+
+  test("the previous window's count decays as its weight falls", async () => {
+    // This is the property that distinguishes a sliding window from the fixed
+    // window in 004: capacity comes back gradually instead of all at once.
+
+    // Half the window left -> the previous window's 30 requests count as ~15,
+    // leaving real headroom. Under 004 this client would still be locked out.
+    const halfway = "decay:half-weight";
+    await seed(halfway, 0, MAX, 150);
+    const half = await check(halfway);
+    expect(half.allowed).toBe(true);
+    // estimate = 30 * 0.5 = 15 -> CEIL(15) + 1 = 16. Seeding drift can nudge
+    // the weight a hair below 0.5, so allow one unit of slack either way.
+    expect(half.request_count).toBeGreaterThanOrEqual(15);
+    expect(half.request_count).toBeLessThanOrEqual(17);
+    // The point of the case: meaningful budget remains.
+    expect(half.request_count).toBeLessThan(MAX);
+
+    // Almost the whole window left -> the previous window's burst still counts
+    // at nearly full weight, so the client stays denied.
+    const nearlyFull = "decay:near-full-weight";
+    await seed(nearlyFull, 0, MAX + 1, 299);
+    const full = await check(nearlyFull);
+    // estimate = 31 * (299/300) = 30.9 >= 30
+    expect(full.allowed).toBe(false);
+    // ...but capacity is close, so Retry-After must be small, not a full window.
+    // retry = reset - window * (30/31) = now + 299 - 290.3 ~= now + 9s.
+    expect(full.reset_in_seconds).toBeGreaterThan(0);
+    expect(full.reset_in_seconds).toBeLessThan(30);
+  });
+
+  test("009 regression: a stale reset_time from a longer window is clamped", async () => {
+    // REGRESSION TEST for migration 009 — the most important case in this file.
+    //
+    // Rows written under the old 1-hour config carry a reset_time far beyond
+    // the 5-minute window now being passed in. In 008 the boundary was only
+    // recomputed once it had ELAPSED, so such a row kept its distant boundary
+    // forever:
+    //
+    //   weight = (reset_time - now) / window = 2400s / 300s = 8.0 -> LEAST(1.0) = 1.0
+    //
+    // The weight pinned at 1.0, the window never rolled, the count never
+    // decayed, and Retry-After was computed off the distant boundary:
+    //
+    //   before 009: (now + 2400 + 300) - 300 * (30/82) = now + 2590s = 43.2 min
+    //   after  009: reset clamps to now + 300, giving
+    //               (now + 300 + 300) - 300 * (30/82) = now + 490s = 8.2 min
+    //
+    // 43 minutes is exactly the lockout that 008 exists to eliminate.
+    const id = "clamp:stale-hour-window";
+    await seed(id, 82, 0, 2400); // 40 minutes out, from the old 1-hour config
+
+    const result = await check(id, MAX, WINDOW_MS);
+
+    expect(result.allowed).toBe(false);
+    expect(result.request_count).toBe(82);
+
+    // The assertion that fails without 009: Retry-After must fit inside two
+    // windows (600s), not trail the stale 2400s boundary.
+    expect(result.reset_in_seconds).toBeGreaterThan(0);
+    expect(result.reset_in_seconds).toBeLessThanOrEqual(2 * WINDOW_S);
+    // Tighter: the measured post-fix value is ~490s. Well under the ~2590s
+    // that 008 produced.
+    expect(result.reset_in_seconds).toBeGreaterThan(400);
+    expect(result.reset_in_seconds).toBeLessThan(560);
+
+    // The clamp must also be persisted, so the row self-heals: the next request
+    // sees an in-range boundary rather than recomputing the clamp forever.
+    const stored = await readRow(id);
+    expect(stored.reset_in_seconds).toBeLessThanOrEqual(WINDOW_S + 1);
+    expect(stored.reset_in_seconds).toBeGreaterThan(WINDOW_S - 5);
+  });
+
+  test("identifiers hold independent budgets", async () => {
+    // The middleware builds `${ip}:${path}[:${scope}]` identifiers precisely so
+    // one exhausted bucket cannot deny another (a dead refresh_token loop must
+    // not consume the authorization_code budget).
+    const exhausted = "1.2.3.4:/token:refresh_token";
+    const healthy = "1.2.3.4:/token:authorization_code";
+
+    await seed(exhausted, MAX, 0, 150);
+
+    expect((await check(exhausted)).allowed).toBe(false);
+    expect(await check(healthy)).toMatchObject({ allowed: true, request_count: 1 });
+  });
+});

--- a/tests/session-rehydration.test.ts
+++ b/tests/session-rehydration.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Tests for the MCP session rehydration mechanism (src/server/mcp-endpoints.ts).
+ *
+ * After a restart / idle eviction this server rebuilds a session the process has
+ * no memory of, instead of forcing every connected client to re-handshake. That
+ * trick leans on three pieces of SDK behaviour that are real but undocumented,
+ * and which a future `@modelcontextprotocol/server` bump could silently remove:
+ *
+ *   1. A transport constructed WITHOUT `sessionIdGenerator` runs in stateless
+ *      mode, where `validateSession()` bails out immediately
+ *      (`if (this.sessionIdGenerator === void 0) return;`) rather than rejecting
+ *      the request with "Bad Request: Server not initialized".
+ *   2. `sessionId` is a public, mutable field on the transport, and every
+ *      header-emitting branch is guarded only by `sessionId !== undefined`, so
+ *      assigning it makes responses keep echoing the client's original id.
+ *   3. A stateless transport can be REUSED across many requests. SDK v1
+ *      explicitly banned this; v2 silently dropped the guard. Upstream PR
+ *      typescript-sdk#2421 intends to restore it.
+ *
+ * These tests drive the SDK directly (transport + `McpServer` + web-standard
+ * `Request` objects) rather than going through Hono, so they fail on an SDK
+ * regression and nothing else.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  isInitializeRequest,
+  McpServer,
+  WebStandardStreamableHTTPServerTransport,
+} from "@modelcontextprotocol/server";
+import { z } from "zod";
+
+const MCP_URL = "http://localhost/mcp";
+
+/** A session id that was handed out by a process which no longer exists. */
+const PRE_EXISTING_SESSION_ID = "11111111-2222-3333-4444-555555555555";
+
+/** Mirrors the production server: an McpServer with at least one real tool. */
+function createTestServer(): McpServer {
+  const server = new McpServer(
+    { name: "rehydration-test", version: "0.0.0" },
+    { capabilities: { tools: {} } }
+  );
+
+  server.registerTool(
+    "echo",
+    {
+      title: "Echo",
+      description: "Returns its input, so tools/call has something to assert.",
+      inputSchema: z.object({ value: z.string() }),
+    },
+    ({ value }) => ({ content: [{ type: "text" as const, text: `echo:${value}` }] })
+  );
+
+  return server;
+}
+
+/**
+ * Build a rehydrated transport exactly the way `rehydrateSession()` does:
+ * stateless mode (no `sessionIdGenerator`) plus a hand-assigned `sessionId`.
+ */
+async function rehydrateTransport(
+  sessionId: string,
+  onsessionclosed?: (id?: string) => void
+): Promise<WebStandardStreamableHTTPServerTransport> {
+  const transport = new WebStandardStreamableHTTPServerTransport(
+    onsessionclosed ? { onsessionclosed } : {}
+  );
+  transport.sessionId = sessionId;
+  await createTestServer().connect(transport);
+  return transport;
+}
+
+function postRequest(body: unknown, sessionId?: string): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+
+  return new Request(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function deleteRequest(sessionId: string): Request {
+  return new Request(MCP_URL, {
+    method: "DELETE",
+    headers: { "mcp-session-id": sessionId },
+  });
+}
+
+interface JsonRpcEnvelope {
+  jsonrpc: string;
+  id?: unknown;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Responses are SSE by default (`event: message` / `data: {...}`); fall back to
+ * plain JSON for `enableJsonResponse` transports and for SDK error responses,
+ * which are always `Response.json(...)`.
+ */
+async function readJsonRpc(response: Response): Promise<JsonRpcEnvelope> {
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (!contentType.includes("text/event-stream")) {
+    return JSON.parse(text) as JsonRpcEnvelope;
+  }
+
+  const dataLine = text
+    .split("\n")
+    .find((line) => line.startsWith("data: "));
+  if (!dataLine) {
+    throw new Error(`No SSE data line in response payload: ${text}`);
+  }
+
+  return JSON.parse(dataLine.slice("data: ".length)) as JsonRpcEnvelope;
+}
+
+function toolsListRequest(id: number): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, method: "tools/list", params: {} };
+}
+
+function toolsCallRequest(id: number, value: string): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "echo", arguments: { value } },
+  };
+}
+
+function initializeMessage(id: number = 1): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    },
+  };
+}
+
+/** The SDK's per-request bookkeeping, reachable only through a cast. */
+interface TransportInternals {
+  _streamMapping: Map<unknown, unknown>;
+  _requestToStreamMapping: Map<unknown, unknown>;
+  _requestResponseMap: Map<unknown, unknown>;
+}
+
+function internals(
+  transport: WebStandardStreamableHTTPServerTransport
+): TransportInternals {
+  return transport as unknown as TransportInternals;
+}
+
+describe("MCP session rehydration", () => {
+  describe("baseline: what a restart used to do", () => {
+    test("a fresh STATEFUL transport rejects a pre-existing session id with 400", async () => {
+      // This is the bug rehydration exists to fix: after a restart every client
+      // still holds a session id, but the new process has a virgin stateful
+      // transport whose `_initialized` flag is false, so `validateSession()`
+      // rejects the request outright.
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+      });
+      await createTestServer().connect(transport);
+
+      const response = await transport.handleRequest(
+        postRequest(toolsListRequest(1), PRE_EXISTING_SESSION_ID)
+      );
+
+      expect(response.status).toBe(400);
+
+      const body = await readJsonRpc(response);
+      expect(body.error?.message).toContain("Server not initialized");
+
+      await transport.close();
+    });
+  });
+
+  describe("rehydration", () => {
+    test("a stateless transport with an assigned sessionId serves tools/list", async () => {
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+
+      const response = await transport.handleRequest(
+        postRequest(toolsListRequest(1), PRE_EXISTING_SESSION_ID)
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await readJsonRpc(response);
+      expect(body.error).toBeUndefined();
+
+      const tools = body.result?.tools as Array<{ name: string }> | undefined;
+      expect(tools?.map((tool) => tool.name)).toContain("echo");
+
+      await transport.close();
+    });
+
+    test("a rehydrated transport serves tools/call", async () => {
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+
+      const response = await transport.handleRequest(
+        postRequest(toolsCallRequest(2, "hello"), PRE_EXISTING_SESSION_ID)
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await readJsonRpc(response);
+      expect(body.error).toBeUndefined();
+
+      const content = body.result?.content as
+        | Array<{ type: string; text: string }>
+        | undefined;
+      expect(content?.[0]?.text).toBe("echo:hello");
+
+      await transport.close();
+    });
+
+    test("the client's original session id is echoed back", async () => {
+      // Header emission is guarded only by `sessionId !== undefined`, so the
+      // hand-assigned id keeps flowing back and the client never learns that
+      // the session was rebuilt.
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+
+      const response = await transport.handleRequest(
+        postRequest(toolsListRequest(1), PRE_EXISTING_SESSION_ID)
+      );
+
+      expect(response.headers.get("mcp-session-id")).toBe(
+        PRE_EXISTING_SESSION_ID
+      );
+
+      await response.text();
+      await transport.close();
+    });
+
+    test("a GET stream on a rehydrated transport is accepted", async () => {
+      // `handleMcp` forwards GET (the client's server-to-client SSE stream) to
+      // the same rehydrated transport, so `validateSession()` must let it past.
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+
+      const response = await transport.handleRequest(
+        new Request(MCP_URL, {
+          method: "GET",
+          headers: {
+            Accept: "text/event-stream",
+            "mcp-session-id": PRE_EXISTING_SESSION_ID,
+          },
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("mcp-session-id")).toBe(
+        PRE_EXISTING_SESSION_ID
+      );
+
+      await transport.close();
+      await response.body?.cancel().catch(() => {});
+    });
+  });
+
+  describe("transport reuse (guards typescript-sdk#2421)", () => {
+    test("one rehydrated transport serves many sequential requests without leaking", async () => {
+      // SDK v1 threw when a stateless transport handled a second request; v2
+      // dropped that guard, which is what makes a single long-lived rehydrated
+      // transport per session viable. Upstream PR #2421 wants the guard back.
+      //
+      // IF THIS TEST FAILS AFTER AN SDK BUMP: the reuse guard was most likely
+      // reinstated. Rehydration then needs reworking — e.g. building a fresh
+      // transport per request, or restoring real stateful sessions — rather
+      // than relaxing this assertion.
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+      const REQUEST_COUNT = 50;
+
+      for (let i = 0; i < REQUEST_COUNT; i++) {
+        const request =
+          i % 2 === 0
+            ? toolsListRequest(i)
+            : toolsCallRequest(i, `call-${i}`);
+
+        const response = await transport.handleRequest(
+          postRequest(request, PRE_EXISTING_SESSION_ID)
+        );
+
+        expect(response.status).toBe(200);
+
+        const body = await readJsonRpc(response);
+        expect(body.error).toBeUndefined();
+        expect(body.id).toBe(i);
+      }
+
+      // Per-request bookkeeping must be torn down as each response completes,
+      // otherwise a long-lived rehydrated transport is a memory leak.
+      const maps = internals(transport);
+      expect(maps._streamMapping).toBeInstanceOf(Map);
+      expect(maps._requestToStreamMapping).toBeInstanceOf(Map);
+      expect(maps._requestResponseMap).toBeInstanceOf(Map);
+
+      expect(maps._streamMapping.size).toBe(0);
+      expect(maps._requestToStreamMapping.size).toBe(0);
+      expect(maps._requestResponseMap.size).toBe(0);
+
+      await transport.close();
+    });
+  });
+
+  describe("session teardown", () => {
+    test("DELETE fires onsessionclosed on a rehydrated transport", async () => {
+      // `rehydrateSession()` relies on this to drop the Supabase row when a
+      // client explicitly ends the session.
+      let closedCalls = 0;
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID, () => {
+        closedCalls++;
+      });
+
+      const response = await transport.handleRequest(
+        deleteRequest(PRE_EXISTING_SESSION_ID)
+      );
+
+      expect(response.status).toBe(200);
+      expect(closedCalls).toBe(1);
+    });
+
+    test("onclose fires when a rehydrated transport is torn down", async () => {
+      // The idle sweep closes transports directly, so `onclose` is the hook
+      // that drops the in-memory Map entry.
+      let closed = false;
+      const transport = await rehydrateTransport(PRE_EXISTING_SESSION_ID);
+      transport.onclose = () => {
+        closed = true;
+      };
+
+      await transport.close();
+
+      expect(closed).toBe(true);
+    });
+  });
+
+  describe("isInitializeMessage semantics", () => {
+    // `isInitializeMessage` is not exported, so its two dependencies are tested
+    // directly: `isInitializeRequest`'s behaviour, and `Array.prototype.some`
+    // over it. `handleMcp` calls it on EVERY request — including GET and DELETE,
+    // which have no body at all — so it must tolerate `undefined`.
+
+    test("recognises a single initialize message", () => {
+      expect(isInitializeRequest(initializeMessage())).toBe(true);
+    });
+
+    test("recognises an array containing an initialize message", () => {
+      const batch = [
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        initializeMessage(7),
+      ];
+
+      expect(batch.some((message) => isInitializeRequest(message))).toBe(true);
+    });
+
+    test("rejects a non-initialize message", () => {
+      expect(isInitializeRequest(toolsListRequest(1))).toBe(false);
+      expect(
+        [toolsListRequest(1), toolsCallRequest(2, "x")].some((message) =>
+          isInitializeRequest(message)
+        )
+      ).toBe(false);
+    });
+
+    test("returns false for undefined without throwing (the GET/DELETE case)", () => {
+      expect(() => isInitializeRequest(undefined)).not.toThrow();
+      expect(isInitializeRequest(undefined)).toBe(false);
+      expect(isInitializeRequest(null)).toBe(false);
+    });
+
+    test("is not confused by the extra arguments Array#some passes", () => {
+      // The production wrapper is `body.some((m) => isInitializeRequest(m))`
+      // rather than `body.some(isInitializeRequest)` precisely so the index and
+      // source array are never forwarded. Assert the arity assumption holds.
+      expect(isInitializeRequest.length).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/tests/timestamp.test.ts
+++ b/tests/timestamp.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Unit tests for src/utils/timestamp.ts
+ *
+ * These tests assert what the code ACTUALLY does today, including a couple of
+ * places where the real behaviour is looser than the doc comments suggest.
+ * Those are called out inline as KNOWN GAP so the suite records reality rather
+ * than an aspiration.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  dateToUnixTimestamp,
+  formatTimestamp,
+  formatTimestampWithTimezone,
+  addReadableTimestamps,
+  addReadableNightEvents,
+} from "../src/utils/timestamp.js";
+
+// Every key the module treats as a Unix timestamp (TIMESTAMP_FIELDS).
+const TIMESTAMP_FIELDS = [
+  "startdate",
+  "enddate",
+  "date",
+  "created",
+  "modified",
+  "timestamp",
+  "first_session_date",
+  "last_session_date",
+  "birthdate",
+  "lastupdate",
+];
+
+// 2024-01-15T11:30:00Z — winter, so Europe/Paris is UTC+1.
+const WINTER_TS = 1705318200;
+// 2024-07-17T10:00:00Z — summer, so Europe/Paris is UTC+2 (CEST).
+const SUMMER_TS = 1721210400;
+
+describe("dateToUnixTimestamp", () => {
+  test("converts YYYY-MM-DD to seconds at midnight UTC", () => {
+    expect(dateToUnixTimestamp("2025-11-17")).toBe(1763337600);
+    expect(dateToUnixTimestamp("1970-01-01")).toBe(0);
+    expect(dateToUnixTimestamp("2024-02-29")).toBe(1709164800); // valid leap day
+  });
+
+  test("returns whole seconds, not milliseconds", () => {
+    const ts = dateToUnixTimestamp("2025-06-01");
+    expect(Number.isInteger(ts)).toBe(true);
+    expect(ts % 86400).toBe(0);
+  });
+
+  test("handles dates before the epoch", () => {
+    expect(dateToUnixTimestamp("1969-12-31")).toBe(-86400);
+  });
+
+  test.each([
+    ["empty string", ""],
+    ["missing separators", "20251117"],
+    ["slash separators", "2025/11/17"],
+    ["single-digit month", "2025-1-17"],
+    ["single-digit day", "2025-11-7"],
+    ["two-digit year", "25-11-17"],
+    ["non-numeric", "abcd-ef-gh"],
+    ["partially non-numeric", "2025-1a-17"],
+    ["ISO datetime", "2025-11-17T00:00:00Z"],
+    ["trailing whitespace", "2025-11-17 "],
+  ])("rejects malformed input (%s)", (_label, input) => {
+    expect(() => dateToUnixTimestamp(input)).toThrow(/Invalid date format/);
+  });
+
+  test("rejects month 0 and month 13", () => {
+    expect(() => dateToUnixTimestamp("2025-00-15")).toThrow(
+      "Invalid month: 0. Must be between 1 and 12."
+    );
+    expect(() => dateToUnixTimestamp("2025-13-15")).toThrow(
+      "Invalid month: 13. Must be between 1 and 12."
+    );
+  });
+
+  test("rejects day 0 and day 32", () => {
+    expect(() => dateToUnixTimestamp("2025-01-00")).toThrow(
+      "Invalid day: 0. Must be between 1 and 31."
+    );
+    expect(() => dateToUnixTimestamp("2025-01-32")).toThrow(
+      "Invalid day: 32. Must be between 1 and 31."
+    );
+  });
+
+  // KNOWN GAP: validation only range-checks month (1-12) and day (1-31); it
+  // never checks the day against the actual length of that month. Date.UTC()
+  // silently rolls the overflow forward, so calendar-impossible dates are
+  // accepted and quietly resolve to a DIFFERENT day. Documented, not endorsed.
+  test("KNOWN GAP: impossible dates roll over instead of throwing", () => {
+    // 2025-02-30 does not exist; it becomes 2025-03-02.
+    const rolled = dateToUnixTimestamp("2025-02-30");
+    expect(formatTimestamp(rolled)).toBe("2025-03-02T00:00:00.000Z");
+
+    // 2025 is not a leap year, so 2025-02-29 becomes 2025-03-01.
+    expect(formatTimestamp(dateToUnixTimestamp("2025-02-29"))).toBe(
+      "2025-03-01T00:00:00.000Z"
+    );
+
+    // 2025-04-31 does not exist; it becomes 2025-05-01.
+    expect(formatTimestamp(dateToUnixTimestamp("2025-04-31"))).toBe(
+      "2025-05-01T00:00:00.000Z"
+    );
+  });
+});
+
+describe("formatTimestamp", () => {
+  test("formats as UTC ISO 8601 with milliseconds", () => {
+    expect(formatTimestamp(WINTER_TS)).toBe("2024-01-15T11:30:00.000Z");
+    expect(formatTimestamp(0)).toBe("1970-01-01T00:00:00.000Z");
+  });
+
+  test("truncates nothing — fractional seconds become milliseconds", () => {
+    expect(formatTimestamp(1705318200.5)).toBe("2024-01-15T11:30:00.500Z");
+  });
+});
+
+describe("formatTimestampWithTimezone", () => {
+  test("formats a known timestamp in Europe/Paris", () => {
+    expect(formatTimestampWithTimezone(WINTER_TS, "Europe/Paris")).toBe(
+      "2024-01-15 12:30:00 Europe/Paris"
+    );
+  });
+
+  test("formats a known timestamp in America/New_York", () => {
+    expect(formatTimestampWithTimezone(WINTER_TS, "America/New_York")).toBe(
+      "2024-01-15 06:30:00 America/New_York"
+    );
+  });
+
+  test("respects DST: same zone shifts by an extra hour in summer", () => {
+    // Winter: UTC 11:30 -> 12:30 local (UTC+1)
+    expect(formatTimestampWithTimezone(WINTER_TS, "Europe/Paris")).toBe(
+      "2024-01-15 12:30:00 Europe/Paris"
+    );
+    expect(formatTimestamp(WINTER_TS)).toBe("2024-01-15T11:30:00.000Z");
+
+    // Summer: UTC 10:00 -> 12:00 local (UTC+2, CEST)
+    expect(formatTimestampWithTimezone(SUMMER_TS, "Europe/Paris")).toBe(
+      "2024-07-17 12:00:00 Europe/Paris"
+    );
+    expect(formatTimestamp(SUMMER_TS)).toBe("2024-07-17T10:00:00.000Z");
+  });
+
+  test("formats UTC midnight local time without hour12 artefacts", () => {
+    // 2024-01-14T23:00:00Z is 2024-01-15 00:00:00 in Paris.
+    expect(formatTimestampWithTimezone(1705273200, "Europe/Paris")).toBe(
+      "2024-01-15 00:00:00 Europe/Paris"
+    );
+  });
+
+  test("falls back to UTC ISO when the timezone is invalid", () => {
+    expect(formatTimestampWithTimezone(WINTER_TS, "Not/AZone")).toBe(
+      formatTimestamp(WINTER_TS)
+    );
+    expect(formatTimestampWithTimezone(WINTER_TS, "")).toBe(
+      formatTimestamp(WINTER_TS)
+    );
+  });
+
+  test("UTC as a named zone matches the ISO rendering", () => {
+    expect(formatTimestampWithTimezone(WINTER_TS, "UTC")).toBe(
+      "2024-01-15 11:30:00 UTC"
+    );
+  });
+});
+
+describe("addReadableTimestamps", () => {
+  test("replaces every field in TIMESTAMP_FIELDS", () => {
+    const input: Record<string, unknown> = {};
+    for (const field of TIMESTAMP_FIELDS) input[field] = WINTER_TS;
+
+    const out = addReadableTimestamps(input);
+
+    for (const field of TIMESTAMP_FIELDS) {
+      expect(out[field]).toBe("2024-01-15T11:30:00.000Z");
+    }
+  });
+
+  test("uses the object's own timezone when present", () => {
+    const out = addReadableTimestamps({
+      timezone: "Europe/Paris",
+      startdate: WINTER_TS,
+      enddate: SUMMER_TS,
+    });
+
+    expect(out).toEqual({
+      timezone: "Europe/Paris",
+      startdate: "2024-01-15 12:30:00 Europe/Paris",
+      enddate: "2024-07-17 12:00:00 Europe/Paris",
+    });
+  });
+
+  test("falls back to UTC ISO when no timezone field is present", () => {
+    const out = addReadableTimestamps({ startdate: WINTER_TS });
+    expect(out.startdate).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  test("ignores a non-string or empty timezone and uses UTC", () => {
+    expect(addReadableTimestamps({ timezone: "", startdate: WINTER_TS }).startdate).toBe(
+      "2024-01-15T11:30:00.000Z"
+    );
+    expect(addReadableTimestamps({ timezone: 3600, startdate: WINTER_TS }).startdate).toBe(
+      "2024-01-15T11:30:00.000Z"
+    );
+  });
+
+  test("leaves unrelated fields untouched", () => {
+    const out = addReadableTimestamps({
+      startdate: WINTER_TS,
+      steps: 8421,
+      model: "Body Cardio",
+      afib: 0,
+      active: true,
+      note: null,
+      hr: [60, 61, 62],
+    });
+
+    expect(out.steps).toBe(8421);
+    expect(out.model).toBe("Body Cardio");
+    expect(out.afib).toBe(0);
+    expect(out.active).toBe(true);
+    expect(out.note).toBe(null);
+    expect(out.hr).toEqual([60, 61, 62]);
+    expect(out.startdate).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  test("only converts positive numbers — 0, negatives and strings pass through", () => {
+    const out = addReadableTimestamps({
+      startdate: 0,
+      enddate: -1,
+      date: "2024-01-15",
+      created: "1705318200",
+    });
+
+    expect(out.startdate).toBe(0);
+    expect(out.enddate).toBe(-1);
+    expect(out.date).toBe("2024-01-15");
+    expect(out.created).toBe("1705318200");
+  });
+
+  test("recurses into nested objects", () => {
+    const out = addReadableTimestamps({
+      body: {
+        series: {
+          startdate: WINTER_TS,
+          nested: { enddate: WINTER_TS },
+        },
+      },
+    });
+
+    expect(out.body.series.startdate).toBe("2024-01-15T11:30:00.000Z");
+    expect(out.body.series.nested.enddate).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  test("recurses into arrays, including arrays of objects", () => {
+    const out = addReadableTimestamps({
+      series: [
+        { timezone: "Europe/Paris", startdate: WINTER_TS },
+        { startdate: WINTER_TS },
+      ],
+    });
+
+    expect(out.series[0].startdate).toBe("2024-01-15 12:30:00 Europe/Paris");
+    expect(out.series[1].startdate).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  test("processes a top-level array", () => {
+    const out = addReadableTimestamps([
+      { timezone: "UTC", date: WINTER_TS },
+      { date: WINTER_TS },
+    ]);
+
+    expect(Array.isArray(out)).toBe(true);
+    expect(out[0].date).toBe("2024-01-15 11:30:00 UTC");
+    expect(out[1].date).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  // Timezone is resolved per-object, not inherited down the tree.
+  test("a nested object does NOT inherit the parent's timezone", () => {
+    const out = addReadableTimestamps({
+      timezone: "Europe/Paris",
+      startdate: WINTER_TS,
+      child: { startdate: WINTER_TS },
+    });
+
+    expect(out.startdate).toBe("2024-01-15 12:30:00 Europe/Paris");
+    expect(out.child.startdate).toBe("2024-01-15T11:30:00.000Z");
+  });
+
+  test("returns null, undefined and primitives unchanged", () => {
+    expect(addReadableTimestamps(null)).toBe(null);
+    expect(addReadableTimestamps(undefined)).toBe(undefined);
+    expect(addReadableTimestamps(42)).toBe(42);
+    expect(addReadableTimestamps("hello")).toBe("hello");
+    expect(addReadableTimestamps(false)).toBe(false);
+  });
+
+  test("does not mutate the input object", () => {
+    const input = { startdate: WINTER_TS, nested: { enddate: WINTER_TS } };
+    const out = addReadableTimestamps(input);
+
+    expect(input.startdate).toBe(WINTER_TS);
+    expect(input.nested.enddate).toBe(WINTER_TS);
+    expect(out).not.toBe(input);
+  });
+
+  test("realistic Withings sleep summary shape", () => {
+    const out = addReadableTimestamps({
+      status: 0,
+      body: {
+        series: [
+          {
+            id: 1,
+            timezone: "Europe/Paris",
+            startdate: WINTER_TS,
+            enddate: WINTER_TS + 3600,
+            modified: WINTER_TS,
+            data: { sleep_score: 82, hr_average: 55 },
+          },
+        ],
+        more: false,
+      },
+    });
+
+    expect(out.status).toBe(0);
+    expect(out.body.more).toBe(false);
+    expect(out.body.series[0].id).toBe(1);
+    expect(out.body.series[0].startdate).toBe("2024-01-15 12:30:00 Europe/Paris");
+    expect(out.body.series[0].enddate).toBe("2024-01-15 13:30:00 Europe/Paris");
+    expect(out.body.series[0].modified).toBe("2024-01-15 12:30:00 Europe/Paris");
+    expect(out.body.series[0].data).toEqual({ sleep_score: 82, hr_average: 55 });
+  });
+});
+
+describe("addReadableNightEvents", () => {
+  test("converts each timestamp array using the object's timezone", () => {
+    const out = addReadableNightEvents({
+      timezone: "Europe/Paris",
+      startdate: WINTER_TS,
+      night_events: {
+        "1": [WINTER_TS, WINTER_TS + 60],
+        "2": [SUMMER_TS],
+      },
+    });
+
+    expect(out.night_events).toEqual({
+      "1": ["2024-01-15 12:30:00 Europe/Paris", "2024-01-15 12:31:00 Europe/Paris"],
+      "2": ["2024-07-17 12:00:00 Europe/Paris"],
+    });
+  });
+
+  test("falls back to UTC ISO when no timezone is present", () => {
+    const out = addReadableNightEvents({
+      night_events: { "1": [WINTER_TS] },
+    });
+
+    expect(out.night_events).toEqual({ "1": ["2024-01-15T11:30:00.000Z"] });
+  });
+
+  test("leaves sibling fields intact and does not mutate the input", () => {
+    const input = {
+      timezone: "UTC",
+      sleep_score: 90,
+      night_events: { "1": [WINTER_TS] },
+    };
+    const out = addReadableNightEvents(input);
+
+    expect(out.timezone).toBe("UTC");
+    expect(out.sleep_score).toBe(90);
+    expect(input.night_events["1"]).toEqual([WINTER_TS]);
+    expect(out).not.toBe(input);
+  });
+
+  test("returns input unchanged when night_events is missing or falsy", () => {
+    const noEvents = { timezone: "UTC", startdate: WINTER_TS };
+    expect(addReadableNightEvents(noEvents)).toBe(noEvents);
+    expect(addReadableNightEvents(null)).toBe(null);
+    expect(addReadableNightEvents(undefined)).toBe(undefined);
+    expect(addReadableNightEvents({ night_events: null })).toEqual({
+      night_events: null,
+    });
+  });
+
+  test("does NOT touch top-level timestamp fields — that is addReadableTimestamps' job", () => {
+    const out = addReadableNightEvents({
+      timezone: "Europe/Paris",
+      startdate: WINTER_TS,
+      night_events: { "1": [WINTER_TS] },
+    });
+
+    expect(out.startdate).toBe(WINTER_TS);
+  });
+
+  // KNOWN GAP: only array values are copied into the rebuilt night_events
+  // object, so any non-array entry is silently dropped rather than preserved.
+  test("KNOWN GAP: non-array night_events entries are dropped", () => {
+    const out = addReadableNightEvents({
+      night_events: { "1": [WINTER_TS], "2": WINTER_TS, "3": "oops" },
+    });
+
+    expect(Object.keys(out.night_events)).toEqual(["1"]);
+    expect(out.night_events["2"]).toBeUndefined();
+  });
+
+  test("empty night_events object stays empty", () => {
+    const out = addReadableNightEvents({ night_events: {} });
+    expect(out.night_events).toEqual({});
+  });
+});
+
+describe("round trip", () => {
+  test.each(["2025-11-17", "2024-02-29", "1970-01-01", "2000-01-01", "2099-12-31"])(
+    "dateToUnixTimestamp -> formatTimestamp preserves the calendar date (%s)",
+    (dateString) => {
+      const iso = formatTimestamp(dateToUnixTimestamp(dateString));
+      expect(iso).toBe(`${dateString}T00:00:00.000Z`);
+      expect(iso.slice(0, 10)).toBe(dateString);
+    }
+  );
+
+  test("round trip survives addReadableTimestamps with a UTC timezone", () => {
+    const out = addReadableTimestamps({
+      timezone: "UTC",
+      startdate: dateToUnixTimestamp("2025-11-17"),
+    });
+    expect(out.startdate).toBe("2025-11-17 00:00:00 UTC");
+  });
+});

--- a/tests/timestamp.test.ts
+++ b/tests/timestamp.test.ts
@@ -221,7 +221,7 @@ describe("addReadableTimestamps", () => {
     expect(out.model).toBe("Body Cardio");
     expect(out.afib).toBe(0);
     expect(out.active).toBe(true);
-    expect(out.note).toBe(null);
+    expect(out.note).toBeNull();
     expect(out.hr).toEqual([60, 61, 62]);
     expect(out.startdate).toBe("2024-01-15T11:30:00.000Z");
   });
@@ -290,8 +290,8 @@ describe("addReadableTimestamps", () => {
   });
 
   test("returns null, undefined and primitives unchanged", () => {
-    expect(addReadableTimestamps(null)).toBe(null);
-    expect(addReadableTimestamps(undefined)).toBe(undefined);
+    expect(addReadableTimestamps(null)).toBeNull();
+    expect(addReadableTimestamps(undefined)).toBeUndefined();
     expect(addReadableTimestamps(42)).toBe(42);
     expect(addReadableTimestamps("hello")).toBe("hello");
     expect(addReadableTimestamps(false)).toBe(false);
@@ -376,8 +376,8 @@ describe("addReadableNightEvents", () => {
   test("returns input unchanged when night_events is missing or falsy", () => {
     const noEvents = { timezone: "UTC", startdate: WINTER_TS };
     expect(addReadableNightEvents(noEvents)).toBe(noEvents);
-    expect(addReadableNightEvents(null)).toBe(null);
-    expect(addReadableNightEvents(undefined)).toBe(undefined);
+    expect(addReadableNightEvents(null)).toBeNull();
+    expect(addReadableNightEvents(undefined)).toBeUndefined();
     expect(addReadableNightEvents({ night_events: null })).toEqual({
       night_events: null,
     });

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Unit tests for the MCP token rotation / refresh logic in src/auth/token-store.ts.
+ *
+ * These guard shipped bugs, not hypotheticals:
+ *
+ *  - `rotateToken()` used to be a bare `UPDATE ... WHERE mcp_token = old` with no
+ *    check on rows affected. Under two concurrent refreshes BOTH reported success,
+ *    and the loser handed its freshly minted token to the client even though the
+ *    UPDATE had matched nothing. That token was never written, so it
+ *    authenticated nothing and the client was stranded. It now chains `.select()`
+ *    and returns a boolean the caller must respect.
+ *
+ *  - The session-ownership cascade after a rotation is deliberately non-fatal:
+ *    mcp_tokens is already committed by then, so throwing would 500 the /token
+ *    response while the client holds a token that no longer exists.
+ *
+ * Supabase is replaced wholesale by tests/helpers/fake-supabase.ts via Bun's
+ * module mocking. Note the `.js` specifier: src/ imports `../db/supabase.js` for
+ * a `.ts` file, so the mock has to use the same specifier to resolve to the same
+ * module record. If the mock ever stops taking effect, the real
+ * `getSupabaseClient()` throws "Supabase client not initialized" — these tests
+ * fail loudly rather than silently passing. The "module mocking is wired up"
+ * test below asserts that directly.
+ */
+
+// Must be set before anything calls encrypt()/decrypt(). Static imports are
+// hoisted above this line, but src/utils/encryption.ts reads the secret lazily
+// inside getMasterSecret(), and the modules under test are imported dynamically
+// further down — after this assignment has run.
+process.env.ENCRYPTION_SECRET =
+  "test-only-throwaway-encryption-secret-not-a-real-key";
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import {
+  makeFakeSupabase,
+  rows,
+  noRows,
+  type Handler,
+  type Operation,
+} from "./helpers/fake-supabase.js";
+
+type Fake = ReturnType<typeof makeFakeSupabase>;
+
+// Mutable so each test can install its own table handlers; the mocked
+// getSupabaseClient() reads it at call time, not at import time.
+let fake: Fake = makeFakeSupabase({});
+
+function useSupabase(handlers: Record<string, Handler>): Fake {
+  fake = makeFakeSupabase(handlers);
+  return fake;
+}
+
+mock.module("../src/db/supabase.js", () => ({
+  getSupabaseClient: () => fake.client,
+}));
+
+const { tokenStore } = await import("../src/auth/token-store.js");
+const { encrypt } = await import("../src/utils/encryption.js");
+
+// Mirrors the constants in src/auth/token-store.ts.
+const TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const ROTATION_GRACE_MS = 60 * 1000;
+
+const OLD_TOKEN = "mcp-token-old-11111111";
+const NEW_TOKEN = "mcp-token-new-22222222";
+
+function tokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    mcp_token: OLD_TOKEN,
+    encrypted_access_token: encrypt("withings-access-abc"),
+    encrypted_refresh_token: encrypt("withings-refresh-xyz"),
+    withings_user_id: "withings-user-42",
+    withings_expires_at: 1_700_000_000,
+    expires_at: new Date(Date.now() + TTL_MS).toISOString(),
+    ...overrides,
+  };
+}
+
+const findFilter = (op: Operation, column: string, kind: "eq" | "gt") =>
+  op.filters.find((f) => f.column === column && f.op === kind);
+
+/** Handler that answers an `UPDATE ... RETURNING` with the given affected rows. */
+const updateAffects = (affected: unknown[]): Handler => () => ({
+  data: affected,
+  error: null,
+});
+
+/** mcp_sessions handler for a cascade that succeeds. */
+const sessionsOk: Handler = () => ({ data: null, error: null });
+
+/** mcp_sessions handler that makes sessionStore.rotateToken() throw. */
+const sessionsBroken: Handler = () => ({
+  data: null,
+  error: { message: "sessions table unavailable" },
+});
+
+beforeEach(() => {
+  // Default: no handlers registered, so any unexpected table access surfaces
+  // as an explicit error instead of a silent pass.
+  useSupabase({});
+});
+
+describe("module mocking is wired up", () => {
+  test("the real token-store talks to the fake supabase client", async () => {
+    const f = useSupabase({ mcp_tokens: noRows });
+
+    // If mock.module had not resolved to src/db/supabase.ts, the real
+    // getSupabaseClient() would throw "Supabase client not initialized".
+    await expect(tokenStore.getTokens("anything")).resolves.toBeNull();
+
+    expect(f.callsFor("mcp_tokens")).toHaveLength(1);
+    expect(f.callsFor("mcp_tokens")[0]!.action).toBe("select");
+  });
+});
+
+describe("rotateToken - concurrent rotation race detection", () => {
+  test("returns TRUE when the UPDATE matched a row", async () => {
+    useSupabase({
+      mcp_tokens: updateAffects([{ mcp_token: NEW_TOKEN }]),
+      mcp_sessions: sessionsOk,
+    });
+
+    await expect(tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)).resolves.toBe(
+      true
+    );
+  });
+
+  test("returns FALSE when the UPDATE matched ZERO rows (lost the race)", async () => {
+    // THE REGRESSION: a concurrent refresh already rotated OLD_TOKEN away, so
+    // this UPDATE matches nothing. `data: []` is exactly what PostgREST returns
+    // for an UPDATE ... RETURNING that affected no rows. Before the fix this
+    // still reported success and NEW_TOKEN — a value never written to any row —
+    // was handed to the client, which then authenticated nothing.
+    const f = useSupabase({
+      mcp_tokens: updateAffects([]),
+      mcp_sessions: sessionsOk,
+    });
+
+    const rotated = await tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN);
+
+    expect(rotated).toBe(false);
+    expect(rotated).not.toBe(true); // the caller MUST NOT issue NEW_TOKEN
+
+    // The UPDATE must actually ask for the affected rows back — without the
+    // chained .select() there is nothing to count and the race is undetectable.
+    const update = f.callsFor("mcp_tokens").at(-1)!;
+    expect(update.action).toBe("update");
+    expect(update.returning).toBe(true);
+
+    // A rotation that did not happen must not drag sessions along with it.
+    expect(f.callsFor("mcp_sessions")).toHaveLength(0);
+  });
+
+  test("returns FALSE when the driver reports no data at all", async () => {
+    useSupabase({
+      mcp_tokens: rows(null),
+      mcp_sessions: sessionsOk,
+    });
+
+    await expect(tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)).resolves.toBe(
+      false
+    );
+  });
+
+  test("the two outcomes are distinguishable from a single boolean", async () => {
+    useSupabase({
+      mcp_tokens: updateAffects([{ mcp_token: NEW_TOKEN }]),
+      mcp_sessions: sessionsOk,
+    });
+    const won = await tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN);
+
+    useSupabase({
+      mcp_tokens: updateAffects([]),
+      mcp_sessions: sessionsOk,
+    });
+    const lost = await tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN);
+
+    expect([won, lost]).toEqual([true, false]);
+  });
+});
+
+describe("rotateToken - written payload", () => {
+  test("records the superseded token and a ~60s grace expiry", async () => {
+    const f = useSupabase({
+      mcp_tokens: updateAffects([{ mcp_token: NEW_TOKEN }]),
+      mcp_sessions: sessionsOk,
+    });
+
+    const before = Date.now();
+    await tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN);
+    const after = Date.now();
+
+    const ops = f.callsFor("mcp_tokens");
+    expect(ops).toHaveLength(1);
+
+    const op = ops[0]!;
+    expect(op.action).toBe("update");
+    expect(op.returning).toBe(true);
+
+    const payload = op.payload as Record<string, string>;
+    expect(payload.mcp_token).toBe(NEW_TOKEN);
+    expect(payload.previous_mcp_token).toBe(OLD_TOKEN);
+
+    // previous_token_expires_at ~= now + ROTATION_GRACE_MS (60s).
+    const graceAt = Date.parse(payload.previous_token_expires_at!);
+    expect(Number.isNaN(graceAt)).toBe(false);
+    expect(graceAt).toBeGreaterThanOrEqual(before + ROTATION_GRACE_MS);
+    expect(graceAt).toBeLessThanOrEqual(after + ROTATION_GRACE_MS);
+    // Sanity: it is a short grace, not the 30-day TTL by accident.
+    expect(graceAt - before).toBeLessThan(5 * 60 * 1000);
+
+    // The row TTL is refreshed to the full 30 days.
+    const expiresAt = Date.parse(payload.expires_at!);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + TTL_MS);
+    expect(expiresAt).toBeLessThanOrEqual(after + TTL_MS);
+
+    expect(Number.isNaN(Date.parse(payload.updated_at!))).toBe(false);
+
+    // Targeted at the presented token only.
+    expect(findFilter(op, "mcp_token", "eq")).toEqual({
+      column: "mcp_token",
+      op: "eq",
+      value: OLD_TOKEN,
+    });
+  });
+});
+
+describe("rotateToken - database errors", () => {
+  test("throws when Supabase returns an error", async () => {
+    useSupabase({
+      mcp_tokens: () => ({
+        data: null,
+        error: { message: "deadlock detected" },
+      }),
+      mcp_sessions: sessionsOk,
+    });
+
+    await expect(
+      tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)
+    ).rejects.toThrow("Failed to rotate token: deadlock detected");
+  });
+
+  test("a database error is not silently downgraded to false", async () => {
+    const f = useSupabase({
+      mcp_tokens: () => ({ data: null, error: { message: "boom" } }),
+      mcp_sessions: sessionsOk,
+    });
+
+    await expect(
+      tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)
+    ).rejects.toThrow(/boom/);
+
+    expect(f.callsFor("mcp_sessions")).toHaveLength(0);
+  });
+});
+
+describe("rotateToken - session ownership cascade", () => {
+  test("carries session ownership over to the new token", async () => {
+    const f = useSupabase({
+      mcp_tokens: updateAffects([{ mcp_token: NEW_TOKEN }]),
+      mcp_sessions: sessionsOk,
+    });
+
+    await expect(tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)).resolves.toBe(
+      true
+    );
+
+    const sessionOps = f.callsFor("mcp_sessions");
+    expect(sessionOps).toHaveLength(1);
+
+    const op = sessionOps[0]!;
+    expect(op.action).toBe("update");
+    expect((op.payload as Record<string, string>).mcp_token).toBe(NEW_TOKEN);
+    expect(findFilter(op, "mcp_token", "eq")).toEqual({
+      column: "mcp_token",
+      op: "eq",
+      value: OLD_TOKEN,
+    });
+  });
+
+  test("still resolves TRUE when the session cascade throws", async () => {
+    // Deliberately non-fatal. mcp_tokens is already committed at this point, so
+    // propagating would 500 the /token response after the rotation succeeded —
+    // the client would keep a token that no longer exists and be locked out
+    // until it redid the whole Withings OAuth flow. A stale session binding
+    // costs one 403 and a reconnect instead.
+    const f = useSupabase({
+      mcp_tokens: updateAffects([{ mcp_token: NEW_TOKEN }]),
+      mcp_sessions: sessionsBroken,
+    });
+
+    await expect(tokenStore.rotateToken(OLD_TOKEN, NEW_TOKEN)).resolves.toBe(
+      true
+    );
+
+    // It genuinely attempted the cascade rather than skipping it.
+    expect(f.callsFor("mcp_sessions")).toHaveLength(1);
+  });
+});
+
+describe("resolveRefreshToken", () => {
+  const PRESENTED = OLD_TOKEN;
+  const CURRENT = NEW_TOKEN;
+
+  /**
+   * resolveRefreshToken makes up to two SELECTs against mcp_tokens; route them
+   * by which column they filter on.
+   */
+  const byLookup = (opts: {
+    live?: Handler;
+    superseded?: Handler;
+  }): Handler => (op) => {
+    if (findFilter(op, "previous_mcp_token", "eq")) {
+      return (opts.superseded ?? noRows)(op);
+    }
+    return (opts.live ?? noRows)(op);
+  };
+
+  test("resolves a live token with isReplay=false", async () => {
+    const f = useSupabase({
+      mcp_tokens: byLookup({ live: rows({ mcp_token: PRESENTED }) }),
+    });
+
+    await expect(tokenStore.resolveRefreshToken(PRESENTED)).resolves.toEqual({
+      currentToken: PRESENTED,
+      isReplay: false,
+    });
+
+    // Short-circuits: no second lookup when the token is still live.
+    const ops = f.callsFor("mcp_tokens");
+    expect(ops).toHaveLength(1);
+
+    const op = ops[0]!;
+    expect(op.action).toBe("select");
+    expect(op.single).toBe(true);
+    expect(findFilter(op, "mcp_token", "eq")?.value).toBe(PRESENTED);
+    expect(findFilter(op, "expires_at", "gt")).toBeDefined();
+  });
+
+  test("resolves a superseded token inside the grace window to the CURRENT token", async () => {
+    const f = useSupabase({
+      mcp_tokens: byLookup({
+        live: noRows,
+        superseded: rows({ mcp_token: CURRENT }),
+      }),
+    });
+
+    const before = new Date(Date.now() - 1).toISOString();
+    const resolved = await tokenStore.resolveRefreshToken(PRESENTED);
+    const after = new Date(Date.now() + 1).toISOString();
+
+    // The caller must be handed the winner's token, not the one it presented.
+    expect(resolved).toEqual({ currentToken: CURRENT, isReplay: true });
+    expect(resolved!.currentToken).not.toBe(PRESENTED);
+
+    const ops = f.callsFor("mcp_tokens");
+    expect(ops).toHaveLength(2);
+
+    const second = ops[1]!;
+    expect(second.action).toBe("select");
+    expect(second.single).toBe(true);
+
+    // Matched on the superseded column...
+    expect(findFilter(second, "previous_mcp_token", "eq")).toEqual({
+      column: "previous_mcp_token",
+      op: "eq",
+      value: PRESENTED,
+    });
+
+    // ...and guarded by BOTH expiries: the 60s grace AND the row's own TTL.
+    // Dropping either would keep a rotated-away token usable well past the
+    // grace window.
+    const grace = findFilter(second, "previous_token_expires_at", "gt");
+    const ttl = findFilter(second, "expires_at", "gt");
+    expect(grace).toBeDefined();
+    expect(ttl).toBeDefined();
+
+    for (const guard of [grace!, ttl!]) {
+      const value = guard.value as string;
+      expect(typeof value).toBe("string");
+      expect(value >= before && value <= after).toBe(true);
+    }
+  });
+
+  test("returns null when neither the live nor the grace lookup matches", async () => {
+    const f = useSupabase({ mcp_tokens: byLookup({}) });
+
+    await expect(
+      tokenStore.resolveRefreshToken("mcp-token-never-issued")
+    ).resolves.toBeNull();
+
+    // Both lookups were genuinely attempted before giving up.
+    expect(f.callsFor("mcp_tokens")).toHaveLength(2);
+  });
+
+  test("returns null when the grace window has elapsed (no matching row)", async () => {
+    // Past the grace window the `previous_token_expires_at > now()` guard
+    // filters the row out server-side, which surfaces as PGRST116 / no rows.
+    const f = useSupabase({ mcp_tokens: byLookup({ superseded: noRows }) });
+
+    await expect(tokenStore.resolveRefreshToken(PRESENTED)).resolves.toBeNull();
+    expect(f.callsFor("mcp_tokens")).toHaveLength(2);
+  });
+});
+
+describe("getTokens / isValid are unchanged", () => {
+  test("returns decrypted Withings credentials for a live token", async () => {
+    const f = useSupabase({ mcp_tokens: rows(tokenRow()) });
+
+    const before = new Date(Date.now() - 1).toISOString();
+    const data = await tokenStore.getTokens(OLD_TOKEN);
+    const after = new Date(Date.now() + 1).toISOString();
+
+    expect(data).toEqual({
+      withingsAccessToken: "withings-access-abc",
+      withingsRefreshToken: "withings-refresh-xyz",
+      withingsUserId: "withings-user-42",
+      expiresAt: 1_700_000_000,
+    });
+
+    const op = f.callsFor("mcp_tokens")[0]!;
+    expect(op.action).toBe("select");
+    expect(op.single).toBe(true);
+    expect(findFilter(op, "mcp_token", "eq")?.value).toBe(OLD_TOKEN);
+
+    const ttlGuard = findFilter(op, "expires_at", "gt")!;
+    expect(ttlGuard).toBeDefined();
+    const value = ttlGuard.value as string;
+    expect(value >= before && value <= after).toBe(true);
+  });
+
+  test("returns null for a token with no matching row", async () => {
+    useSupabase({ mcp_tokens: noRows });
+
+    await expect(tokenStore.getTokens("mcp-token-missing")).resolves.toBeNull();
+  });
+
+  test("isValid is true for a live token", async () => {
+    useSupabase({ mcp_tokens: rows(tokenRow()) });
+
+    await expect(tokenStore.isValid(OLD_TOKEN)).resolves.toBe(true);
+  });
+
+  test("isValid is false for a missing token", async () => {
+    useSupabase({ mcp_tokens: noRows });
+
+    await expect(tokenStore.isValid("mcp-token-missing")).resolves.toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "resolveJsonModule": true,
     "types": ["bun"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
The repo had no tests, no runner config and no CI. Two rate-limiter bugs shipped to production in one afternoon — both of a kind a fixture would have caught. This adds the harness plus coverage aimed squarely at them.

**201 tests across 7 files. No new dependencies** — `bun test` and Bun's built-in SQL client.

```
181 pass · 20 skip (need TEST_DATABASE_URL) · 0 fail
```

## Regression coverage for what actually broke

**`interval * numeric`** — Postgres has no such operator, only `interval * double precision`, and the expression lives **only on the denied path** of `check_rate_limit`. Every rate-limited request raised instead of returning 429. A happy-path suite would have shipped it again, so both denial branches (`v_current >= max`, and `v_previous > 0`) are exercised separately.

**Stale `reset_time`** — a row written under a longer window kept its distant boundary, pinning the decay weight at 1.0 so the window never rolled and `Retry-After` came back as ~43 minutes. Migration 009 (#39) clamps it.

I validated this one against **production, which does not have 009 yet**: the scenario returns **2590s** there, against an assertion of **< 600s**. So the test genuinely *fails on unfixed code* rather than merely passing on fixed code — which is the only version of a regression test worth having.

**`rotateToken` race** — the bare `UPDATE` returned a token that had never been written when a concurrent refresh won. Covered by asserting the true/false split and that `.select()` is still chained. The agent who wrote it mutation-tested this: reverting `rotateToken` to its old shape turns 4 tests red.

**Stateless transport reuse** — session rehydration depends on the SDK allowing a stateless transport to be reused, a guard v1 enforced and v2 dropped. [typescript-sdk#2421](https://github.com/modelcontextprotocol/typescript-sdk/pull/2421) intends to restore it, which would break rehydration silently. 50 sequential requests through one rehydrated transport assert the internal maps return to zero.

## How the SQL tests work

They **seed `rate_limits` directly** rather than sleeping, so a 5-minute window is testable in milliseconds. The deployed function has no clock parameter, so placing the row at an arbitrary point in its window is the only way to test decay without a slow suite.

They skip when `TEST_DATABASE_URL` is unset and run in CI against `postgres:17`. The harness applies the **real migrations** into a throwaway schema — so migration syntax and ordering are themselves under test — provisioning the Supabase-only roles and stripping `pg_cron` calls a stock server cannot run.

Three hand-traced expected values were confirmed exactly against real Postgres: window roll → `CEIL(12 × 0.8) + 1 = 11`, weighted decay → denied with 9s retry, at-limit → denied at 30.

## tsconfig now includes `tests/`

Not cosmetic: `include` was `["src/**/*"]`, so `bun run typecheck` never type-checked a single test file. Widening it **immediately surfaced a type error** that would otherwise have sat there indefinitely.

## Pre-existing bugs found — pinned, not fixed

Tests document current behaviour and are marked `KNOWN GAP`, so fixing them is a deliberate separate decision:

1. **`dateToUnixTimestamp` accepts impossible dates.** Day is range-checked 1–31 but never against the month's real length, and `Date.UTC` silently rolls over — `"2025-02-30"` → 2025-03-02. **A user asking for end-of-February data silently gets March.** This one has real user impact and I'd suggest fixing it.
2. `addReadableNightEvents` drops non-array entries from the response.
3. Logger redaction matches key names only, so a secret interpolated into a message string is logged verbatim.
4. `categorizeError` checks `"date"` before the missing-param case, so `"startdate is required"` mis-categorises.

## Also

Corrects a comment in `mcp-endpoints.ts`: this SDK version *does* pass the real session id to `onsessionclosed`, not `undefined`. Closing over the id remains deliberate and is now explained as future-proofing rather than stated as fact.

## Test plan

- [x] `bun test` → 181 pass, 20 skip, 0 fail
- [x] `bun run typecheck` clean, now covering `tests/`
- [x] Key SQL assertions verified against real Postgres; probe rows/tables cleaned up and absence confirmed
- [ ] CI green (first run of the 20 DB tests — they have never executed end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
