### PR TITLE
feat: add dedicated HRV sleep tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ After authorization, Claude will have access to your Withings data!
 Once connected, Claude can use these tools to access your data:
 
 #### Sleep & Activity
+- `get_hrv` - Minute-level RMSSD and SDNN heart-rate variability captured during sleep
 - `get_sleep_summary` - Sleep duration, stages (light/deep/REM), heart rate, breathing, sleep score
 - `get_activity` - Daily steps, distance, calories, elevation, activity durations
 - `get_intraday_activity` - High-frequency activity data throughout the day

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ After authorization, Claude will have access to your Withings data!
 Once connected, Claude can use these tools to access your data:
 
 #### Sleep & Activity
-- `get_hrv` - Minute-level RMSSD and SDNN heart-rate variability captured during sleep
+- `get_hrv` - Minute-level RMSSD, SDNN, and quality scores captured during sleep
 - `get_sleep_summary` - Sleep duration, stages (light/deep/REM), heart rate, breathing, sleep score
 - `get_activity` - Daily steps, distance, calories, elevation, activity durations
 - `get_intraday_activity` - High-frequency activity data throughout the day

--- a/src/tools/sleep.ts
+++ b/src/tools/sleep.ts
@@ -9,6 +9,46 @@ import { withAnalytics, TOOL_ANNOTATIONS, toolResponse } from "./index.js";
 import type { SleepSummary } from "../types/withings.js";
 
 export function registerSleepTools(server: McpServer, mcpAccessToken: string) {
+  // Sleep v2 - Get: Dedicated HRV access
+  server.registerTool(
+    "get_hrv",
+    {
+      title: "Heart Rate Variability During Sleep",
+      description:
+        "Get heart rate variability (HRV) captured during sleep at minute-level resolution. Returns RMSSD (root mean square of successive differences) and SDNN (standard deviation of NN intervals) values in milliseconds. Use one sleep period per request: Withings returns at most the first 24 hours after startdate. IMPORTANT: Before executing this tool, if the user's request references relative dates (like 'today', 'yesterday', or 'last night'), check if there is a date/time MCP tool available to detect the current date and time first.",
+      inputSchema: z.object({
+        startdate: z
+          .string()
+          .describe(
+            "Sleep period start date in YYYY-MM-DD format (e.g., '2025-11-17'). The date represents midnight UTC of that day."
+          ),
+        enddate: z
+          .string()
+          .describe(
+            "Sleep period end date in YYYY-MM-DD format (e.g., '2025-11-18'). Maximum 24h range from startdate."
+          ),
+      }),
+      annotations: TOOL_ANNOTATIONS,
+    },
+    (args) => {
+      return withAnalytics(
+        "get_hrv",
+        async () => {
+          const hrvData = await getSleep(
+            mcpAccessToken,
+            args.startdate,
+            args.enddate,
+            "rmssd,sdnn_1"
+          );
+
+          return toolResponse(addReadableTimestamps(hrvData));
+        },
+        { mcpAccessToken },
+        args
+      );
+    }
+  );
+
   // Sleep v2 - Get: High-frequency sleep data with timestamps
   server.registerTool(
     "get_sleep",

--- a/src/tools/sleep.ts
+++ b/src/tools/sleep.ts
@@ -15,7 +15,7 @@ export function registerSleepTools(server: McpServer, mcpAccessToken: string) {
     {
       title: "Heart Rate Variability During Sleep",
       description:
-        "Get heart rate variability (HRV) captured during sleep at minute-level resolution. Returns RMSSD (root mean square of successive differences) and SDNN (standard deviation of NN intervals) values in milliseconds. Use one sleep period per request: Withings returns at most the first 24 hours after startdate. IMPORTANT: Before executing this tool, if the user's request references relative dates (like 'today', 'yesterday', or 'last night'), check if there is a date/time MCP tool available to detect the current date and time first.",
+        "Get heart rate variability (HRV) captured during sleep at minute-level resolution. Returns timestamp-keyed maps of RMSSD (root mean square of successive differences), SDNN (standard deviation of NN intervals), and HRV quality scores. RMSSD and SDNN values are in milliseconds; sample-map keys are Unix timestamps in seconds. Use one sleep period per request: Withings returns at most the first 24 hours after startdate. IMPORTANT: Before executing this tool, if the user's request references relative dates (like 'today', 'yesterday', or 'last night'), check if there is a date/time MCP tool available to detect the current date and time first.",
       inputSchema: z.object({
         startdate: z
           .string()
@@ -38,7 +38,7 @@ export function registerSleepTools(server: McpServer, mcpAccessToken: string) {
             mcpAccessToken,
             args.startdate,
             args.enddate,
-            "rmssd,sdnn_1"
+            "rmssd,sdnn_1,hrv_quality"
           );
 
           return toolResponse(addReadableTimestamps(hrvData));

--- a/src/types/withings.ts
+++ b/src/types/withings.ts
@@ -16,8 +16,9 @@ export interface SleepSeries {
   hr?: Record<string, number>;
   rr?: Record<string, number>;
   snoring?: Record<string, number>;
-  rmssd?: number;
-  sdnn_1?: number;
+  rmssd?: Record<string, number>;
+  sdnn_1?: Record<string, number>;
+  hrv_quality?: Record<string, number>;
   [key: string]: unknown;
 }
 

--- a/src/types/withings.ts
+++ b/src/types/withings.ts
@@ -16,6 +16,8 @@ export interface SleepSeries {
   hr?: Record<string, number>;
   rr?: Record<string, number>;
   snoring?: Record<string, number>;
+  rmssd?: number;
+  sdnn_1?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

- add a dedicated `get_hrv` MCP tool for discoverable HRV access
- request Withings Sleep v2 fields `rmssd` and `sdnn_1` automatically
- preserve readable timestamp conversion, analytics, and read-only annotations
- document the tool and type the HRV response fields

The generic `get_sleep` tool already supports these data fields, but a dedicated tool makes HRV available without requiring MCP clients or users to know Withings-specific field names.

## API behavior

Withings Sleep v2 returns at most the first 24 hours after `startdate`, so the tool accepts one sleep period per request and documents that limit.

Official Withings Postman reference: https://www.postman.com/withings/withings-health-solutions/request/h9wsugu/sleep-v2-get

## Validation

- `bun test`: 181 passed, 20 database-dependent tests skipped, 0 failed
- `bun run typecheck`
- `bun run build`